### PR TITLE
Smooth scrolling, and a bottom row that holds its water

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ sw.*
 
 # Vim swap files
 *.swp
+
+# Playwright MCP scratch output
+.playwright-mcp/

--- a/app/composables/useFluidWorld.ts
+++ b/app/composables/useFluidWorld.ts
@@ -280,14 +280,34 @@ export function useFluidWorld() {
     stats.particles = fluid.value.count
   }
 
+  /** Is the staging row on screen and diggable at this column? */
+  function inStagingRow(blockX: number, blockY: number): boolean {
+    return (
+      blockY === -1 && staged !== null && blockX >= 0 && blockX < WORLD_WIDTH
+    )
+  }
+
   /** Whether the block at these coordinates is rock. Null out of bounds. */
   function isSolidBlock(blockX: number, blockY: number): boolean | null {
+    // The row part way into view along the bottom is as diggable as any other
+    // — it has to be, or there is no cutting a channel for the water to leave
+    // by until it has finished arriving.
+    if (inStagingRow(blockX, blockY)) return staged!.solid[blockX]!
     const block = game.value.world.getBlock(blockX, blockY)
     return block ? block.blockType.nature === BlockNature.solid : null
   }
 
   /** Set one block to rock or empty; a no-op if it already is. */
   function paintBlock(blockX: number, blockY: number, makeSolid: boolean) {
+    if (blockY < 0) {
+      if (!inStagingRow(blockX, blockY)) return
+      if (staged!.solid[blockX] === makeSolid) return
+      staged!.solid[blockX] = makeSolid
+      changes.value++
+      syncTerrain()
+      if (makeSolid) fluid.value.evictFromSolids()
+      return
+    }
     const world = game.value.world
     const block = world.getBlock(blockX, blockY)
     if (!block) return
@@ -358,6 +378,8 @@ export function useFluidWorld() {
     solidAt,
     /** The smooth part of the scroll, in fluid cells, for the renderer. */
     scrollCells: () => scrollProgress * CELLS_PER_BLOCK,
+    /** The same, in blocks, for working out what the pointer is over. */
+    scrollBlocks: () => scrollProgress,
     changes,
     stats,
     terrainVersion,

--- a/app/composables/useFluidWorld.ts
+++ b/app/composables/useFluidWorld.ts
@@ -6,8 +6,8 @@ import {
   CELLS_PER_BLOCK,
   CELL_BORDER,
   cellsForBlocks,
+  drainLine,
   fillBlock,
-  firstCellOf,
   syncSolids,
 } from '~/scripts/fluid/worldGrid'
 
@@ -266,9 +266,8 @@ export function useFluidWorld() {
     const started = performance.now()
 
     if (drains.value) {
-      // Let water out through the floor, which here means deleting anything
-      // that reaches the lowest open row.
-      const floor = firstCellOf(1) + 0.5
+      // Water is gone once it reaches the bottom of the world, and not before.
+      const floor = drainLine(f.spacing)
       f.removeParticles((_x, y) => y > floor)
     }
 

--- a/app/composables/useFluidWorld.ts
+++ b/app/composables/useFluidWorld.ts
@@ -5,7 +5,7 @@ import { FlipFluid } from '~/scripts/fluid/flipFluid'
 import {
   CELLS_PER_BLOCK,
   fillBlock,
-  firstCellOf,
+  firstCellOfRow,
   gridHeightFor,
   gridWidthFor,
   syncSolids,
@@ -69,16 +69,26 @@ export function useFluidWorld() {
     })
   }
 
+  // The row waiting below the world to scroll in. It is real terrain, kept out
+  // of the block world only because World is a fixed number of rows tall and
+  // growing it would change what a seed generates — the /dom page has to build
+  // the same caves from the same seed.
+  let staged: { solid: boolean[]; water: boolean[] } | null = null
+
+  /** Whether the block at these coordinates is rock, staging row included. */
+  function solidAt(x: number, y: number): boolean {
+    if (y < 0) return staged?.solid[x] ?? true
+    return (
+      game.value.world.getBlock(x, y)?.blockType.nature === BlockNature.solid
+    )
+  }
+
   /** Rock blocks become solid cells; the outside of the world is solid too. */
   function syncTerrain() {
-    const world = game.value.world
-    syncSolids(
-      fluid.value,
-      WORLD_WIDTH,
-      WORLD_HEIGHT,
-      (x, y) => world.getBlock(x, y)?.blockType.nature === BlockNature.solid,
-      drains.value,
-    )
+    syncSolids(fluid.value, WORLD_WIDTH, WORLD_HEIGHT, solidAt, {
+      staged: staged !== null,
+      openFloor: drains.value,
+    })
     fluid.value.drainFloor = drains.value
     terrainVersion.value++
   }
@@ -101,6 +111,7 @@ export function useFluidWorld() {
     next.createRandomWorld(seed.value)
     game.value = next
     fluid.value = makeFluid()
+    staged = null
     syncTerrain()
 
     // Cash the generated water in for particles, then take it out of the block
@@ -116,8 +127,11 @@ export function useFluidWorld() {
       }
     }
     changes.value = 0
-    stats.particles = fluid.value.count
     scrollProgress = 0
+    // A world rebuilt mid-scroll — a change of seed, or of particle fineness —
+    // still needs its next row waiting below it.
+    if (scrolling.value) stageNextRow()
+    stats.particles = fluid.value.count
     relight()
   }
 
@@ -147,42 +161,56 @@ export function useFluidWorld() {
     }
   }
 
-  // Stopping mid-glide would otherwise leave the world drawn part of a block
-  // off its own grid for as long as the scroll stayed off.
+  /**
+   * Build the row that will scroll in next, a whole glide before it is needed,
+   * out of sight below the world — and give it its water there and then, so it
+   * is settling while it is still hidden and arrives already behaving.
+   */
+  function stageNextRow() {
+    staged = game.value.rowBelow(0)
+    syncTerrain()
+    for (let x = 0; x < WORLD_WIDTH; x++) if (staged.water[x]) pourBlock(x, -1)
+    stats.particles = fluid.value.count
+  }
+
+  // Switching the scroll on builds the first row below the world; switching it
+  // off takes the floor back, and the water that had settled into a row nobody
+  // was ever going to see goes with it.
   watch(scrolling, (on) => {
-    if (!on) scrollProgress = 0
+    if (on) {
+      stageNextRow()
+      return
+    }
+    scrollProgress = 0
+    staged = null
+    syncTerrain()
+    fluid.value.evictFromSolids()
+    stats.particles = fluid.value.count
   })
 
-  /** One row of descent: the world slides up and a fresh row rises in. */
+  /** One row of descent: the staged row arrives and the next one is built. */
   function scrollRow() {
-    const g = game.value
-    const world = g.world
-    // The same mutation the block game's scroll makes: drop the top row,
-    // grow a fresh random one at the bottom.
+    const world = game.value.world
+    // The row that has spent the last glide sliding into view is now the
+    // world's bottom row. Its water is already in the simulation and rides up
+    // with everything else — the block only ever carries the rock.
     world.removeRow(WORLD_HEIGHT - 1)
     world.insertRow(0)
-    g.createRandomRow(0)
+    const arriving = staged
+    for (let x = 0; x < WORLD_WIDTH; x++)
+      world.getBlock(x, 0)!.blockType = world.getBlockType(
+        arriving?.solid[x] ? 'rock' : 'empty',
+      )
 
-    // The terrain just moved up a block, so the water goes with it, and
-    // whatever gets pushed past the top has scrolled off the world. The
-    // predicate names what to KEEP.
-    // Past the top of the blocks is off the world — the sky above them is
-    // headroom for a splash to come back down from, not somewhere to ride out
-    // a scroll.
+    // The terrain just moved up a block, so the water goes with it. Past the
+    // top of the blocks is off the world — the sky above them is headroom for
+    // a splash to come back down from, not somewhere to ride out a scroll.
+    // The predicate names what to KEEP.
     const f = fluid.value
     f.shiftParticles(CELLS_PER_BLOCK)
-    f.removeParticles((_x, y) => y < firstCellOf(WORLD_HEIGHT))
-    syncTerrain()
+    f.removeParticles((_x, y) => y < firstCellOfRow(WORLD_HEIGHT))
 
-    // The fresh row may bring water of its own; cash it in for particles
-    // exactly as at generation time.
-    for (let x = 0; x < WORLD_WIDTH; x++) {
-      const block = world.getBlock(x, 0)!
-      if (block.blockType.nature !== BlockNature.liquid) continue
-      block.blockType = world.getBlockType('empty')
-      pourBlock(x, 0)
-    }
-    stats.particles = f.count
+    stageNextRow()
     if (dark.value) relight()
   }
 
@@ -326,6 +354,8 @@ export function useFluidWorld() {
     dark,
     scrolling,
     advanceScroll,
+    /** Rock, the staging row below the world included, for the renderer. */
+    solidAt,
     /** The smooth part of the scroll, in fluid cells, for the renderer. */
     scrollCells: () => scrollProgress * CELLS_PER_BLOCK,
     changes,

--- a/app/composables/useFluidWorld.ts
+++ b/app/composables/useFluidWorld.ts
@@ -2,19 +2,18 @@ import { Game } from '~/scripts/game'
 import { BlockNature } from '~/scripts/blockType'
 import { Item } from '~/scripts/item'
 import { FlipFluid } from '~/scripts/fluid/flipFluid'
+import {
+  CELLS_PER_BLOCK,
+  CELL_BORDER,
+  cellsForBlocks,
+  fillBlock,
+  firstCellOf,
+  syncSolids,
+} from '~/scripts/fluid/worldGrid'
 
 /** World size in blocks for the fluid page. */
 export const WORLD_WIDTH = 50
 export const WORLD_HEIGHT = 25
-
-/**
- * How many fluid cells a block is worth along each axis. The simulation is a
- * grid of its own laid over the block world, and this is the only thing tying
- * the two together. Three would give finer flow but costs more than twice as
- * much per frame — most of the visible detail comes from where the particles
- * are, not from how fine the grid under them is.
- */
-export const CELLS_PER_BLOCK = 2
 
 /** Sized for the finest particle setting; coarser ones simply use less. */
 const MAX_PARTICLES = 96000
@@ -59,8 +58,8 @@ export function useFluidWorld() {
 
   function makeFluid() {
     return new FlipFluid({
-      width: WORLD_WIDTH * CELLS_PER_BLOCK,
-      height: WORLD_HEIGHT * CELLS_PER_BLOCK,
+      width: cellsForBlocks(WORLD_WIDTH),
+      height: cellsForBlocks(WORLD_HEIGHT),
       maxParticles: MAX_PARTICLES,
       spacing: 1 / settings.particlesPerAxis,
       flipRatio: settings.flipRatio,
@@ -71,51 +70,20 @@ export function useFluidWorld() {
   }
 
   /** Rock blocks become solid cells; the outside of the world is solid too. */
-  function syncSolids() {
-    const f = fluid.value
+  function syncTerrain() {
     const world = game.value.world
-    for (let x = 0; x < WORLD_WIDTH; x++) {
-      for (let y = 0; y < WORLD_HEIGHT; y++) {
-        const solid =
-          world.getBlock(x, y)?.blockType.nature === BlockNature.solid
-        for (let ci = 0; ci < CELLS_PER_BLOCK; ci++)
-          for (let cj = 0; cj < CELLS_PER_BLOCK; cj++)
-            f.setSolid(
-              x * CELLS_PER_BLOCK + ci,
-              y * CELLS_PER_BLOCK + cj,
-              solid,
-            )
-      }
-    }
-    // A one cell rim around the world. Half a block thick, so it is invisible
-    // against the terrain, and it means every cell holding water has a real
-    // cell on all four sides for the pressure solve to lean on.
-    for (let i = 0; i < f.width; i++) {
-      f.setSolid(i, 0, true)
-      f.setSolid(i, f.height - 1, true)
-    }
-    for (let j = 0; j < f.height; j++) {
-      f.setSolid(0, j, true)
-      f.setSolid(f.width - 1, j, true)
-    }
+    syncSolids(
+      fluid.value,
+      WORLD_WIDTH,
+      WORLD_HEIGHT,
+      (x, y) => world.getBlock(x, y)?.blockType.nature === BlockNature.solid,
+    )
     terrainVersion.value++
   }
 
-  /** Fill one block's worth of cells with particles at the rest packing. */
-  function fillBlock(blockX: number, blockY: number) {
-    const f = fluid.value
-    const perAxis = settings.particlesPerAxis
-    const step = 1 / perAxis
-    for (let ci = 0; ci < CELLS_PER_BLOCK; ci++) {
-      for (let cj = 0; cj < CELLS_PER_BLOCK; cj++) {
-        const cellX = blockX * CELLS_PER_BLOCK + ci
-        const cellY = blockY * CELLS_PER_BLOCK + cj
-        if (f.isSolid(cellX, cellY)) continue
-        for (let px = 0; px < perAxis; px++)
-          for (let py = 0; py < perAxis; py++)
-            f.addParticle(cellX + (px + 0.5) * step, cellY + (py + 0.5) * step)
-      }
-    }
+  /** Cash one block of generated water in for particles. */
+  function pourBlock(blockX: number, blockY: number) {
+    fillBlock(fluid.value, blockX, blockY, settings.particlesPerAxis)
   }
 
   function generateWorld() {
@@ -123,7 +91,7 @@ export function useFluidWorld() {
     next.createRandomWorld(seed.value)
     game.value = next
     fluid.value = makeFluid()
-    syncSolids()
+    syncTerrain()
 
     // Cash the generated water in for particles, then take it out of the block
     // world — from here on the blocks are only terrain and the particles are
@@ -134,7 +102,7 @@ export function useFluidWorld() {
         const block = world.getBlock(x, y)!
         if (block.blockType.nature !== BlockNature.liquid) continue
         block.blockType = world.getBlockType('empty')
-        fillBlock(x, y)
+        pourBlock(x, y)
       }
     }
     changes.value = 0
@@ -146,8 +114,34 @@ export function useFluidWorld() {
   // How far into the next row the scroll has glided, 0..1 blocks. Drawn as a
   // smooth offset; the world itself only ever moves in whole-row steps.
   let scrollProgress = 0
-  /** Matches the block game's pace: a 20px block at 1px per 100ms. */
+  /** Matches the block game's pace: one row of descent every two seconds. */
   const SECONDS_PER_ROW = 2
+
+  /**
+   * Glide the world up by this much *real* time, stepping a whole row in
+   * whenever the glide passes one.
+   *
+   * Deliberately not driven by the solver's fixed step. The offset is the one
+   * number the eye follows across the whole frame, so it has to be a function
+   * of the wall clock: tied to how many frames have been drawn instead, every
+   * long frame — and the solver has plenty of them — lands the same distance of
+   * travel in a longer slice of time and reads as a stutter, and a display that
+   * is not 60Hz scrolls at the wrong speed entirely.
+   */
+  function advanceScroll(seconds: number) {
+    if (!scrolling.value) return
+    scrollProgress += seconds / SECONDS_PER_ROW
+    while (scrollProgress >= 1) {
+      scrollProgress -= 1
+      scrollRow()
+    }
+  }
+
+  // Stopping mid-glide would otherwise leave the world drawn part of a block
+  // off its own grid for as long as the scroll stayed off.
+  watch(scrolling, (on) => {
+    if (!on) scrollProgress = 0
+  })
 
   /** One row of descent: the world slides up and a fresh row rises in. */
   function scrollRow() {
@@ -164,8 +158,8 @@ export function useFluidWorld() {
     // predicate names what to KEEP.
     const f = fluid.value
     f.shiftParticles(CELLS_PER_BLOCK)
-    f.removeParticles((_x, y) => y < f.height - 1)
-    syncSolids()
+    f.removeParticles((_x, y) => y < f.height - CELL_BORDER)
+    syncTerrain()
 
     // The fresh row may bring water of its own; cash it in for particles
     // exactly as at generation time.
@@ -173,7 +167,7 @@ export function useFluidWorld() {
       const block = world.getBlock(x, 0)!
       if (block.blockType.nature !== BlockNature.liquid) continue
       block.blockType = world.getBlockType('empty')
-      fillBlock(x, 0)
+      pourBlock(x, 0)
     }
     stats.particles = f.count
     if (dark.value) relight()
@@ -241,7 +235,7 @@ export function useFluidWorld() {
 
   /** A row of water along the top of the world, as on the /dom page. */
   function addWater() {
-    for (let x = 0; x < WORLD_WIDTH; x++) fillBlock(x, WORLD_HEIGHT - 1)
+    for (let x = 0; x < WORLD_WIDTH; x++) pourBlock(x, WORLD_HEIGHT - 1)
     stats.particles = fluid.value.count
   }
 
@@ -261,7 +255,7 @@ export function useFluidWorld() {
     // Filling over a torch buries it; a light inside rock is no light at all.
     if (makeSolid && block.item) block.item = null
     changes.value++
-    syncSolids()
+    syncTerrain()
     if (dark.value) relight()
     // Filling a block in can bury water. Anything with nowhere to go is gone.
     if (makeSolid) fluid.value.evictFromSolids()
@@ -274,16 +268,8 @@ export function useFluidWorld() {
     if (drains.value) {
       // Let water out through the floor, which here means deleting anything
       // that reaches the lowest open row.
-      const floor = CELLS_PER_BLOCK + 0.5
+      const floor = firstCellOf(1) + 0.5
       f.removeParticles((_x, y) => y > floor)
-    }
-
-    if (scrolling.value) {
-      scrollProgress += dt / SECONDS_PER_ROW
-      if (scrollProgress >= 1) {
-        scrollProgress -= 1
-        scrollRow()
-      }
     }
 
     f.step(dt)
@@ -331,8 +317,9 @@ export function useFluidWorld() {
     drains,
     dark,
     scrolling,
-    /** The smooth part of the scroll, in blocks, for the renderer. */
-    scrollOffset: () => scrollProgress,
+    advanceScroll,
+    /** The smooth part of the scroll, in fluid cells, for the renderer. */
+    scrollCells: () => scrollProgress * CELLS_PER_BLOCK,
     changes,
     stats,
     terrainVersion,

--- a/app/composables/useFluidWorld.ts
+++ b/app/composables/useFluidWorld.ts
@@ -4,9 +4,10 @@ import { Item } from '~/scripts/item'
 import { FlipFluid } from '~/scripts/fluid/flipFluid'
 import {
   CELLS_PER_BLOCK,
-  CELL_BORDER,
-  cellsForBlocks,
   fillBlock,
+  firstCellOf,
+  gridHeightFor,
+  gridWidthFor,
   syncSolids,
 } from '~/scripts/fluid/worldGrid'
 
@@ -57,8 +58,8 @@ export function useFluidWorld() {
 
   function makeFluid() {
     return new FlipFluid({
-      width: cellsForBlocks(WORLD_WIDTH),
-      height: cellsForBlocks(WORLD_HEIGHT),
+      width: gridWidthFor(WORLD_WIDTH),
+      height: gridHeightFor(WORLD_HEIGHT),
       maxParticles: MAX_PARTICLES,
       spacing: 1 / settings.particlesPerAxis,
       flipRatio: settings.flipRatio,
@@ -165,9 +166,12 @@ export function useFluidWorld() {
     // The terrain just moved up a block, so the water goes with it, and
     // whatever gets pushed past the top has scrolled off the world. The
     // predicate names what to KEEP.
+    // Past the top of the blocks is off the world — the sky above them is
+    // headroom for a splash to come back down from, not somewhere to ride out
+    // a scroll.
     const f = fluid.value
     f.shiftParticles(CELLS_PER_BLOCK)
-    f.removeParticles((_x, y) => y < f.height - CELL_BORDER)
+    f.removeParticles((_x, y) => y < firstCellOf(WORLD_HEIGHT))
     syncTerrain()
 
     // The fresh row may bring water of its own; cash it in for particles

--- a/app/composables/useFluidWorld.ts
+++ b/app/composables/useFluidWorld.ts
@@ -6,7 +6,6 @@ import {
   CELLS_PER_BLOCK,
   CELL_BORDER,
   cellsForBlocks,
-  drainLine,
   fillBlock,
   syncSolids,
 } from '~/scripts/fluid/worldGrid'
@@ -77,9 +76,19 @@ export function useFluidWorld() {
       WORLD_WIDTH,
       WORLD_HEIGHT,
       (x, y) => world.getBlock(x, y)?.blockType.nature === BlockNature.solid,
+      drains.value,
     )
+    fluid.value.drainFloor = drains.value
     terrainVersion.value++
   }
+
+  // The valve is a change to the world's floor, so it is re-laid like any
+  // other. Closing it must not lift water that had already left back into the
+  // world along with the floor it fell through.
+  watch(drains, (open) => {
+    syncTerrain()
+    if (!open) fluid.value.evictFromSolids()
+  })
 
   /** Cash one block of generated water in for particles. */
   function pourBlock(blockX: number, blockY: number) {
@@ -265,12 +274,8 @@ export function useFluidWorld() {
     const f = fluid.value
     const started = performance.now()
 
-    if (drains.value) {
-      // Water is gone once it reaches the bottom of the world, and not before.
-      const floor = drainLine(f.spacing)
-      f.removeParticles((_x, y) => y > floor)
-    }
-
+    // Draining needs nothing here: an open valve is an open floor, and the
+    // water leaves through it under its own weight.
     f.step(dt)
 
     stepMsThisSecond += performance.now() - started

--- a/app/pages/dom.vue
+++ b/app/pages/dom.vue
@@ -98,40 +98,51 @@
         height: (game.height - (scrolling ? 1 : 0)) * game.blockSize + 'px',
       }"
     >
-      <template v-for="(row, rowIndex) in game.world.blocks" :key="rowIndex">
-        <div
-          v-for="block in row"
-          :id="block.key"
-          :key="block.key"
-          class="block"
-          :class="{
-            flowing: block.isFlowing,
-            static: !block.isFlowing,
-          }"
-          :style="{
-            top:
-              game.heightInPx - (block.y + 1) * 20 - game.scrollOffset + 'px',
-            left: block.x * 20 + 'px',
-          }"
-          @click="clickBlock(block, $event)"
-          @mouseover="hoverBlock(block)"
-          @mouseleave="leaveBlock(block)"
-        >
+      <!-- The glide lives on this one element rather than in every block's
+           `top`: 1250 absolutely positioned divs re-laid out every frame is
+           not something that stays smooth, and a transform on their container
+           is a single composited move. -->
+      <div
+        class="rows"
+        :style="{ transform: `translateY(${-game.scrollOffset}px)` }"
+      >
+        <template v-for="(row, rowIndex) in game.world.blocks" :key="rowIndex">
           <div
-            class="fill"
-            :style="{
-              background: block.blockType.background,
-              backgroundImage: `url(/${block.blockType.image})`,
-              height: block.isFlowing ? '100%' : block.percentFilled + '%',
-              width: block.isFlowing ? block.percentFilled + '%' : '100%',
+            v-for="block in row"
+            :id="block.key"
+            :key="block.key"
+            class="block"
+            :class="{
+              flowing: block.isFlowing,
+              static: !block.isFlowing,
             }"
-          />
-          <div v-if="block.item" class="item">
-            {{ block.item ? '🔦' : '' }}
+            :style="{
+              top: game.heightInPx - (block.y + 1) * 20 + 'px',
+              left: block.x * 20 + 'px',
+            }"
+            @click="clickBlock(block, $event)"
+            @mouseover="hoverBlock(block)"
+            @mouseleave="leaveBlock(block)"
+          >
+            <div
+              class="fill"
+              :style="{
+                background: block.blockType.background,
+                backgroundImage: `url(/${block.blockType.image})`,
+                height: block.isFlowing ? '100%' : block.percentFilled + '%',
+                width: block.isFlowing ? block.percentFilled + '%' : '100%',
+              }"
+            />
+            <div v-if="block.item" class="item">
+              {{ block.item ? '🔦' : '' }}
+            </div>
+            <div
+              class="overlay"
+              :style="{ opacity: 0.97 - block.brightness }"
+            />
           </div>
-          <div class="overlay" :style="{ opacity: 0.97 - block.brightness }" />
-        </div>
-      </template>
+        </template>
+      </div>
     </div>
 
     <div class="text-caption text-medium-emphasis mt-2">
@@ -218,10 +229,21 @@ watch(
   },
 )
 
+let previousFrame = 0
+/** A backgrounded tab comes back owing minutes; none of it gets scrolled. */
+const MAX_FRAME_SECONDS = 0.25
+
 onMounted(() => {
   loadFromUrl()
-  const loop = () => {
+  const loop = (now: number) => {
+    if (!previousFrame) previousFrame = now
+    const elapsed = Math.min((now - previousFrame) / 1000, MAX_FRAME_SECONDS)
+    previousFrame = now
+
     const g = game.value
+    // On the wall clock, so the world glides at the same speed whatever the
+    // refresh rate is and a long frame does not read as a stutter.
+    g.advanceScroll(elapsed)
     stats.torches = g.torches
     stats.waterBlocks = g.waterBlocks
     stats.blocksLit = g.blocksLit
@@ -230,7 +252,7 @@ onMounted(() => {
     frame.value++
     rafHandle = requestAnimationFrame(loop)
   }
-  loop()
+  rafHandle = requestAnimationFrame(loop)
 })
 
 // The game owns two intervals; without this they outlive the page.
@@ -335,6 +357,12 @@ function clickBlock(block: Block, event: MouseEvent) {
 }
 .world.scrolling {
   overflow: hidden;
+}
+
+.rows {
+  position: absolute;
+  inset: 0;
+  will-change: transform;
 }
 
 .block.static .fill {

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -47,6 +47,7 @@ const {
   scrolling,
   advanceScroll,
   scrollCells,
+  scrollBlocks,
   solidAt,
   changes,
   stats,
@@ -102,9 +103,28 @@ function pushLight() {
 }
 
 // The renderer keeps its own copies of the rock and the lighting, so they only
-// need rebuilding when something actually changes rather than every frame.
-watch(terrainVersion, pushTerrain)
-watch(lightVersion, pushLight)
+// need rebuilding when something actually changes rather than every frame —
+// but they are rebuilt here, in the frame, rather than from a watcher.
+//
+// A Vue watcher does not run until the current task finishes, and the whole
+// frame happens inside one: the row steps in, the water shifts up with it, the
+// scroll offset snaps back, the frame is drawn — and only then does the
+// watcher get round to the rock. That left one frame every two seconds drawn
+// with terrain a row out of step with the water standing on it, which is the
+// flash a scroll had at every row.
+let pushedTerrain = -1
+let pushedLight = -1
+
+function pushChanges() {
+  if (pushedTerrain !== terrainVersion.value) {
+    pushTerrain()
+    pushedTerrain = terrainVersion.value
+  }
+  if (pushedLight !== lightVersion.value) {
+    pushLight()
+    pushedLight = lightVersion.value
+  }
+}
 
 onMounted(() => {
   const element = canvas.value!
@@ -121,8 +141,6 @@ onMounted(() => {
   resizeObserver.observe(element)
 
   loadFromUrl()
-  pushTerrain()
-  pushLight()
 
   const loop = (now: number) => {
     if (!start) {
@@ -143,6 +161,8 @@ onMounted(() => {
       owed -= FIXED_STEP
     }
 
+    // Last thing before drawing, so what is drawn is all of one moment.
+    pushChanges()
     renderer?.render(fluid.value, (now - start) / 1000, scrollCells())
     rafHandle = requestAnimationFrame(loop)
   }
@@ -171,9 +191,13 @@ function blockAt(event: PointerEvent): { x: number; y: number } | null {
   if (!element) return null
   const rect = element.getBoundingClientRect()
   const x = Math.floor(((event.clientX - rect.left) / rect.width) * WORLD_WIDTH)
-  // Canvas y runs down the screen, the world's y runs up it.
+  // Canvas y runs down the screen, the world's y runs up it — and mid-glide
+  // the world is drawn that fraction of a block higher than it sits, so the
+  // row under the pointer is that much lower than the screen makes it look.
+  // Without this a dig lands up to a whole row away from the cursor, and the
+  // part-arrived row along the bottom cannot be reached at all.
   const fromTop = ((event.clientY - rect.top) / rect.height) * WORLD_HEIGHT
-  return { x, y: Math.floor(WORLD_HEIGHT - fromTop) }
+  return { x, y: Math.floor(WORLD_HEIGHT - fromTop - scrollBlocks()) }
 }
 
 function onPointerDown(event: PointerEvent) {

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -45,7 +45,8 @@ const {
   drains,
   dark,
   scrolling,
-  scrollOffset,
+  advanceScroll,
+  scrollCells,
   changes,
   stats,
   terrainVersion,
@@ -64,6 +65,22 @@ let renderer: FluidRenderer | null = null
 let resizeObserver: ResizeObserver | null = null
 let rafHandle = 0
 let start = 0
+let previousFrame = 0
+let owed = 0
+
+// A fixed step: if the machine cannot keep up the water runs slow rather than
+// exploding, which is the right way round for a solver like this. Real elapsed
+// time is banked and spent a whole step at a time, at most one step a frame.
+//
+// The bank is what stops the water running at double time on a 120Hz screen.
+// The one-step ceiling is what keeps the old bargain: a machine that cannot
+// manage 60 steps a second simply gets slow water, and never a frame asked to
+// do two steps' work because the last one ran long.
+const FIXED_STEP = 1 / 60
+/** Never bank more than a step's worth of arrears; the rest is written off. */
+const MAX_OWED = 2 * FIXED_STEP
+/** A backgrounded tab comes back with minutes owed. None of it gets simulated. */
+const MAX_FRAME_SECONDS = 0.25
 
 function pushTerrain() {
   const world = game.value.world
@@ -92,7 +109,6 @@ onMounted(() => {
     element,
     WORLD_WIDTH,
     WORLD_HEIGHT,
-    CELLS_PER_BLOCK,
     fluid.value.maxParticles,
   )
 
@@ -105,19 +121,29 @@ onMounted(() => {
   pushTerrain()
   pushLight()
 
-  const loop = () => {
-    if (!start) start = performance.now()
-    // A fixed step: if the machine cannot keep up the water runs slow rather
-    // than exploding, which is the right way round for a solver like this.
-    step(1 / 60)
-    renderer?.render(
-      fluid.value,
-      (performance.now() - start) / 1000,
-      scrollOffset() * CELLS_PER_BLOCK,
-    )
+  const loop = (now: number) => {
+    if (!start) {
+      start = now
+      previousFrame = now
+    }
+    const elapsed = Math.min((now - previousFrame) / 1000, MAX_FRAME_SECONDS)
+    previousFrame = now
+
+    // The scroll rides the wall clock, so the world glides at the same speed
+    // however long the frame that draws it took. The solver behind it can fall
+    // behind without that showing up as a stutter.
+    advanceScroll(elapsed)
+
+    owed = Math.min(owed + elapsed, MAX_OWED)
+    if (owed >= FIXED_STEP) {
+      step(FIXED_STEP)
+      owed -= FIXED_STEP
+    }
+
+    renderer?.render(fluid.value, (now - start) / 1000, scrollCells())
     rafHandle = requestAnimationFrame(loop)
   }
-  loop()
+  rafHandle = requestAnimationFrame(loop)
 })
 
 onBeforeUnmount(() => {

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -47,6 +47,7 @@ const {
   scrolling,
   advanceScroll,
   scrollCells,
+  solidAt,
   changes,
   stats,
   terrainVersion,
@@ -82,18 +83,20 @@ const MAX_OWED = 2 * FIXED_STEP
 /** A backgrounded tab comes back with minutes owed. None of it gets simulated. */
 const MAX_FRAME_SECONDS = 0.25
 
+// The renderer asks about the staging row below the world too, at y = -1: it
+// is drawn as a scroll glides it up into view. Torches never go there, and it
+// borrows the brightness of the row it is about to sit under.
 function pushTerrain() {
   const world = game.value.world
-  renderer?.setBlocks(
-    (x, y) => world.getBlock(x, y)?.blockType.nature === BlockNature.solid,
-    (x, y) => world.getBlock(x, y)?.item != null,
+  renderer?.setBlocks(solidAt, (x, y) =>
+    y < 0 ? false : world.getBlock(x, y)?.item != null,
   )
 }
 
 function pushLight() {
   const world = game.value.world
   renderer?.setLight(
-    (x, y) => world.getBlock(x, y)?.brightness ?? 0,
+    (x, y) => world.getBlock(x, Math.max(y, 0))?.brightness ?? 0,
     dark.value,
   )
 }

--- a/app/scripts/fluid/flipFluid.ts
+++ b/app/scripts/fluid/flipFluid.ts
@@ -102,6 +102,19 @@ export class FlipFluid {
   readonly density: Float32Array
   restDensity = 0
 
+  /**
+   * An open floor: water reaching the bottom of the grid falls out of the world
+   * instead of piling up on it.
+   *
+   * Opening it is the caller's job — clearing the solid flags along the bottom
+   * row is what lets gravity onto those faces and what tells the pressure solve
+   * it may push flow through them, and the solve reads `solid` directly. What
+   * this flag does is hold up the other end of that bargain: the row is emptied
+   * of particles at the top of every step, so no cell on the very edge of the
+   * grid is ever water by the time the solve reaches for its neighbours.
+   */
+  drainFloor = false
+
   count = 0
   readonly px: Float32Array
   readonly py: Float32Array
@@ -242,6 +255,10 @@ export class FlipFluid {
   step(dt: number, substeps = 1) {
     const sub = dt / substeps
     for (let s = 0; s < substeps; s++) {
+      // Whatever fell through the floor last step is out of the world, and has
+      // to be gone before the grid is built or it would be water in a cell the
+      // solve is not allowed to have water in.
+      if (this.drainFloor) this.removeParticles((_x, y) => y >= 1)
       this.transferToGrid()
       this.updateDensity()
       this.applyGravity(sub)

--- a/app/scripts/fluid/fluidRenderer.ts
+++ b/app/scripts/fluid/fluidRenderer.ts
@@ -1,6 +1,11 @@
 import * as THREE from 'three'
 import { FLUID, type FlipFluid } from './flipFluid'
-import { CELLS_PER_BLOCK, CELL_BORDER } from './worldGrid'
+import {
+  CELLS_PER_BLOCK,
+  STAGING_BLOCKS,
+  firstCellOfColumn,
+  firstCellOfRow,
+} from './worldGrid'
 
 /**
  * Draws a FlipFluid as liquid rather than as the cloud of particles it is.
@@ -43,12 +48,17 @@ export class FluidRenderer {
   private depthData: Uint8Array
   private blockWidth: number
   private blockHeight: number
-  // The cells the canvas actually shows. The simulation grid is larger — it
-  // carries a solid border outside the world, and a block of open sky above it
-  // for water to have a surface against — so everything read out of it here
-  // starts CELL_BORDER in and stops at the top of the blocks.
+  // The cells the canvas shows at rest, and the cell its bottom-left corner
+  // sits on. The simulation grid is bigger on every side: a solid border, open
+  // sky above for water to have a surface against, and the staging rows below.
   private cellWidth: number
   private cellHeight: number
+  private originX: number
+  private originY: number
+  // Block rows held in the world textures. The staging rows are in there too,
+  // at the bottom, because a scroll glides them up into view and they have to
+  // be drawn while it does.
+  private blockRows: number
   private disposed = false
 
   constructor(
@@ -59,8 +69,14 @@ export class FluidRenderer {
   ) {
     this.blockWidth = blockWidth
     this.blockHeight = blockHeight
+    this.originX = firstCellOfColumn(0)
+    this.originY = firstCellOfRow(0)
+    const blockRows = (this.blockRows = blockHeight + STAGING_BLOCKS)
     const cellWidth = (this.cellWidth = blockWidth * CELLS_PER_BLOCK)
     const cellHeight = (this.cellHeight = blockHeight * CELLS_PER_BLOCK)
+    // The depth field covers the staging rows as well, so water gliding in is
+    // shaded like the water it is rather than reading as a flat sheet.
+    const depthHeight = blockRows * CELLS_PER_BLOCK
 
     this.renderer = new THREE.WebGLRenderer({ canvas, antialias: false })
     this.renderer.setPixelRatio(Math.min(globalThis.devicePixelRatio ?? 1, 2))
@@ -113,11 +129,11 @@ export class FluidRenderer {
     this.particles.frustumCulled = false
     this.particleScene.add(this.particles)
 
-    this.rockData = new Uint8Array(blockWidth * blockHeight * 4)
+    this.rockData = new Uint8Array(blockWidth * blockRows * 4)
     this.rockTexture = new THREE.DataTexture(
       this.rockData,
       blockWidth,
-      blockHeight,
+      blockRows,
     )
     this.rockTexture.minFilter = THREE.NearestFilter
     this.rockTexture.magFilter = THREE.NearestFilter
@@ -125,22 +141,22 @@ export class FluidRenderer {
 
     // Block brightness for dark mode. Linear filtering, so torchlight falls
     // off in a smooth pool instead of block-shaped steps.
-    this.lightData = new Uint8Array(blockWidth * blockHeight)
+    this.lightData = new Uint8Array(blockWidth * blockRows)
     this.lightTexture = new THREE.DataTexture(
       this.lightData,
       blockWidth,
-      blockHeight,
+      blockRows,
       THREE.RedFormat,
     )
     this.lightTexture.minFilter = THREE.LinearFilter
     this.lightTexture.magFilter = THREE.LinearFilter
     this.lightTexture.needsUpdate = true
 
-    this.depthData = new Uint8Array(cellWidth * cellHeight)
+    this.depthData = new Uint8Array(cellWidth * depthHeight)
     this.depthTexture = new THREE.DataTexture(
       this.depthData,
       cellWidth,
-      cellHeight,
+      depthHeight,
       THREE.RedFormat,
     )
     // Linear, unlike the block textures: this one is a smooth quantity and the
@@ -164,6 +180,10 @@ export class FluidRenderer {
         uScroll: { value: 0 },
         uRock: { value: rock },
         uSize: { value: new THREE.Vector2(blockWidth, blockHeight) },
+        // The world textures run from the bottom of the staging rows, so a
+        // fragment's row is its world row plus that offset.
+        uRows: { value: blockRows },
+        uRowOffset: { value: STAGING_BLOCKS },
         uTexel: { value: new THREE.Vector2(1 / 512, 1 / 256) },
         uTime: { value: 0 },
       },
@@ -181,15 +201,16 @@ export class FluidRenderer {
 
   /**
    * Rebuild the rock and torch layer. Only needed when the terrain or the
-   * torches actually change.
+   * torches actually change. Asked about the staging rows too, at negative y —
+   * they are below the world but a scroll brings them into view.
    */
   setBlocks(
     isSolid: (x: number, y: number) => boolean,
     hasTorch: (x: number, y: number) => boolean = () => false,
   ) {
     for (let x = 0; x < this.blockWidth; x++) {
-      for (let y = 0; y < this.blockHeight; y++) {
-        const i = (y * this.blockWidth + x) * 4
+      for (let y = -STAGING_BLOCKS; y < this.blockHeight; y++) {
+        const i = ((y + STAGING_BLOCKS) * this.blockWidth + x) * 4
         this.rockData[i] = isSolid(x, y) ? 255 : 0
         this.rockData[i + 2] = hasTorch(x, y) ? 255 : 0
       }
@@ -200,9 +221,11 @@ export class FluidRenderer {
   /** How lit each block is, and whether that matters at all right now. */
   setLight(brightness: (x: number, y: number) => number, dark: boolean) {
     for (let x = 0; x < this.blockWidth; x++) {
-      for (let y = 0; y < this.blockHeight; y++) {
+      for (let y = -STAGING_BLOCKS; y < this.blockHeight; y++) {
         const lit = Math.min(Math.max(brightness(x, y), 0), 1)
-        this.lightData[y * this.blockWidth + x] = Math.round(lit * 255)
+        this.lightData[(y + STAGING_BLOCKS) * this.blockWidth + x] = Math.round(
+          lit * 255,
+        )
       }
     }
     this.lightTexture.needsUpdate = true
@@ -217,14 +240,15 @@ export class FluidRenderer {
   render(fluid: FlipFluid, elapsedSeconds: number, scrollCells: number = 0) {
     if (this.disposed) return
 
-    // Particle positions are in fluid cells; the shaders want clip space. Cell
-    // CELL_BORDER is the left/bottom edge of the drawn world, not cell 0.
+    // Particle positions are in fluid cells; the shaders want clip space. The
+    // world's bottom-left corner is the origin, not cell 0 — below and around
+    // it are the staging rows and the border.
     const toClipX = 2 / this.cellWidth
     const toClipY = 2 / this.cellHeight
     for (let i = 0; i < fluid.count; i++) {
-      this.positions[i * 3] = (fluid.px[i]! - CELL_BORDER) * toClipX - 1
+      this.positions[i * 3] = (fluid.px[i]! - this.originX) * toClipX - 1
       this.positions[i * 3 + 1] =
-        (fluid.py[i]! - CELL_BORDER + scrollCells) * toClipY - 1
+        (fluid.py[i]! - this.originY + scrollCells) * toClipY - 1
       this.speeds[i] = Math.hypot(fluid.pvx[i]!, fluid.pvy[i]!)
     }
     this.compositeMaterial.uniforms.uScroll!.value =
@@ -281,10 +305,12 @@ export class FluidRenderer {
    */
   private updateDepth(fluid: FlipFluid) {
     const data = this.depthData
+    const rows = this.blockRows * CELLS_PER_BLOCK
+    const bottom = firstCellOfRow(-STAGING_BLOCKS)
     for (let i = 0; i < this.cellWidth; i++) {
       let above = 0
-      const column = (i + CELL_BORDER) * fluid.height + CELL_BORDER
-      for (let j = this.cellHeight - 1; j >= 0; j--) {
+      const column = (i + this.originX) * fluid.height + bottom
+      for (let j = rows - 1; j >= 0; j--) {
         const cell = fluid.cell[column + j]
         // Rock and air both start the count again, so water under a ledge is
         // shaded by its own depth and not by whatever is above the ledge.
@@ -354,6 +380,8 @@ uniform float uDark;
 uniform float uScroll;
 uniform sampler2D uRock;
 uniform vec2 uSize;
+uniform float uRows;
+uniform float uRowOffset;
 uniform vec2 uTexel;
 uniform float uTime;
 
@@ -375,9 +403,15 @@ void main() {
   // while the scroll glides between rows, so they slide in step with the
   // particles, which are offset on their way in. The density field is already
   // in screen space and keeps vUv.
+  //
+  // They all hold the staging rows below the world as well, so a scroll has
+  // real terrain to bring up into the strip that opens along the bottom
+  // instead of the bottom row smeared downwards. Hence the row offset: a
+  // fragment's row in the textures is its row in the world plus that.
   vec2 wUv = vec2(vUv.x, vUv.y - uScroll);
-  vec2 blockPos = wUv * uSize;
-  vec4 blocks = texture2D(uBlocks, (floor(blockPos) + 0.5) / uSize);
+  vec2 blockPos = vec2(wUv.x * uSize.x, wUv.y * uSize.y + uRowOffset);
+  vec2 tUv = vec2(wUv.x, blockPos.y / uRows);
+  vec4 blocks = texture2D(uBlocks, (floor(blockPos) + 0.5) / vec2(uSize.x, uRows));
   float solid = blocks.r;
 
   vec3 cave = vec3(0.045, 0.040, 0.055);
@@ -400,7 +434,7 @@ void main() {
   // How much water stands above this point, worked out on the grid rather than
   // from the field above, which is flat inside a body and so cannot tell a
   // puddle from the bottom of a lake.
-  float depth = clamp(texture2D(uDepth, wUv).r * 255.0 / 8.0 / 9.0, 0.0, 1.0);
+  float depth = clamp(texture2D(uDepth, tUv).r * 255.0 / 8.0 / 9.0, 0.0, 1.0);
 
   vec3 shallow = vec3(0.36, 0.72, 0.78);
   vec3 deep = vec3(0.02, 0.13, 0.34);
@@ -446,7 +480,7 @@ void main() {
 
   // Night is a multiply down to the torch-lit brightness, with a whisper of
   // ambient left so the caves still read as shapes rather than as nothing.
-  float light = texture2D(uLight, wUv).r;
+  float light = texture2D(uLight, tUv).r;
   col = mix(col, col * (0.05 + 0.95 * light), uDark);
 
   // The torch itself is a small warm flame, drawn over the darkness so it can

--- a/app/scripts/fluid/fluidRenderer.ts
+++ b/app/scripts/fluid/fluidRenderer.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three'
 import { FLUID, type FlipFluid } from './flipFluid'
+import { CELLS_PER_BLOCK, CELL_BORDER } from './worldGrid'
 
 /**
  * Draws a FlipFluid as liquid rather than as the cloud of particles it is.
@@ -42,19 +43,23 @@ export class FluidRenderer {
   private depthData: Uint8Array
   private blockWidth: number
   private blockHeight: number
+  // The cells the canvas actually shows. The simulation grid is larger — it
+  // carries a solid border outside the world — so everything read out of it
+  // here is offset by CELL_BORDER and stops short of the far edge.
+  private cellWidth: number
+  private cellHeight: number
   private disposed = false
 
   constructor(
     canvas: HTMLCanvasElement,
     blockWidth: number,
     blockHeight: number,
-    cellsPerBlock: number,
     maxParticles: number,
   ) {
     this.blockWidth = blockWidth
     this.blockHeight = blockHeight
-    const cellWidth = blockWidth * cellsPerBlock
-    const cellHeight = blockHeight * cellsPerBlock
+    const cellWidth = (this.cellWidth = blockWidth * CELLS_PER_BLOCK)
+    const cellHeight = (this.cellHeight = blockHeight * CELLS_PER_BLOCK)
 
     this.renderer = new THREE.WebGLRenderer({ canvas, antialias: false })
     this.renderer.setPixelRatio(Math.min(globalThis.devicePixelRatio ?? 1, 2))
@@ -211,15 +216,18 @@ export class FluidRenderer {
   render(fluid: FlipFluid, elapsedSeconds: number, scrollCells: number = 0) {
     if (this.disposed) return
 
-    // Particle positions are in fluid cells; the shaders want clip space.
-    const toClipX = 2 / fluid.width
-    const toClipY = 2 / fluid.height
+    // Particle positions are in fluid cells; the shaders want clip space. Cell
+    // CELL_BORDER is the left/bottom edge of the drawn world, not cell 0.
+    const toClipX = 2 / this.cellWidth
+    const toClipY = 2 / this.cellHeight
     for (let i = 0; i < fluid.count; i++) {
-      this.positions[i * 3] = fluid.px[i]! * toClipX - 1
-      this.positions[i * 3 + 1] = (fluid.py[i]! + scrollCells) * toClipY - 1
+      this.positions[i * 3] = (fluid.px[i]! - CELL_BORDER) * toClipX - 1
+      this.positions[i * 3 + 1] =
+        (fluid.py[i]! - CELL_BORDER + scrollCells) * toClipY - 1
       this.speeds[i] = Math.hypot(fluid.pvx[i]!, fluid.pvy[i]!)
     }
-    this.compositeMaterial.uniforms.uScroll!.value = scrollCells / fluid.height
+    this.compositeMaterial.uniforms.uScroll!.value =
+      scrollCells / this.cellHeight
     const position = this.particles.geometry.getAttribute('position')
     const speed = this.particles.geometry.getAttribute('speed')
     position.needsUpdate = true
@@ -229,7 +237,7 @@ export class FluidRenderer {
     // A particle's blob spans about three times the rest spacing, so
     // neighbours overlap into a continuous sheet rather than reading as a row
     // of beads, and finer particles draw as proportionally finer detail.
-    const pixelsPerCell = this.density.width / fluid.width
+    const pixelsPerCell = this.density.width / this.cellWidth
     const pointSize = Math.max(pixelsPerCell * fluid.spacing * 6.4, 2)
     this.splatMaterial.uniforms.uPointSize!.value = pointSize
 
@@ -272,14 +280,15 @@ export class FluidRenderer {
    */
   private updateDepth(fluid: FlipFluid) {
     const data = this.depthData
-    for (let i = 0; i < fluid.width; i++) {
+    for (let i = 0; i < this.cellWidth; i++) {
       let above = 0
-      for (let j = fluid.height - 1; j >= 0; j--) {
-        const cell = fluid.cell[i * fluid.height + j]
+      const column = (i + CELL_BORDER) * fluid.height + CELL_BORDER
+      for (let j = this.cellHeight - 1; j >= 0; j--) {
+        const cell = fluid.cell[column + j]
         // Rock and air both start the count again, so water under a ledge is
         // shaded by its own depth and not by whatever is above the ledge.
         above = cell === FLUID ? above + 1 : 0
-        data[j * fluid.width + i] = Math.min(above * 8, 255)
+        data[j * this.cellWidth + i] = Math.min(above * 8, 255)
       }
     }
     this.depthTexture.needsUpdate = true

--- a/app/scripts/fluid/fluidRenderer.ts
+++ b/app/scripts/fluid/fluidRenderer.ts
@@ -44,8 +44,9 @@ export class FluidRenderer {
   private blockWidth: number
   private blockHeight: number
   // The cells the canvas actually shows. The simulation grid is larger — it
-  // carries a solid border outside the world — so everything read out of it
-  // here is offset by CELL_BORDER and stops short of the far edge.
+  // carries a solid border outside the world, and a block of open sky above it
+  // for water to have a surface against — so everything read out of it here
+  // starts CELL_BORDER in and stops at the top of the blocks.
   private cellWidth: number
   private cellHeight: number
   private disposed = false

--- a/app/scripts/fluid/worldGrid.ts
+++ b/app/scripts/fluid/worldGrid.ts
@@ -40,6 +40,20 @@ export function firstCellOf(block: number): number {
 }
 
 /**
+ * The line an open drain takes water away at, in cells.
+ *
+ * The floor of the world plus one particle spacing, which is where the bottom
+ * layer of a body of water comes to rest. Tighter than that and the last of the
+ * water sits on the drain forever; looser, and it is drawn from water that has
+ * not reached the floor yet — which turns the bottom row into a dead band that
+ * water crosses without ever being drawn in it. It must stay inside the bottom
+ * row of blocks, whatever the particles are set to.
+ */
+export function drainLine(spacing: number): number {
+  return firstCellOf(0) + spacing
+}
+
+/**
  * Copy the rock into the simulation and lay the border back down around it.
  * Every block maps onto its own square of cells and nothing else, so the floor
  * the water rests on is exactly the floor that is drawn.

--- a/app/scripts/fluid/worldGrid.ts
+++ b/app/scripts/fluid/worldGrid.ts
@@ -40,29 +40,28 @@ export function firstCellOf(block: number): number {
 }
 
 /**
- * The line an open drain takes water away at, in cells.
- *
- * The floor of the world plus one particle spacing, which is where the bottom
- * layer of a body of water comes to rest. Tighter than that and the last of the
- * water sits on the drain forever; looser, and it is drawn from water that has
- * not reached the floor yet — which turns the bottom row into a dead band that
- * water crosses without ever being drawn in it. It must stay inside the bottom
- * row of blocks, whatever the particles are set to.
- */
-export function drainLine(spacing: number): number {
-  return firstCellOf(0) + spacing
-}
-
-/**
  * Copy the rock into the simulation and lay the border back down around it.
  * Every block maps onto its own square of cells and nothing else, so the floor
  * the water rests on is exactly the floor that is drawn.
+ *
+ * With `openFloor`, the border under the world is left open instead. That is
+ * the drain: water is not deleted where it stands, it falls out through the
+ * bottom of the world, which is both what the valve claims to do and the only
+ * way to have it drain quickly *and* have the bottom row of blocks full of
+ * water on the way. Deleting a band of water instead — however thin — leaves
+ * that band permanently dry, and a band thin enough not to show is also too
+ * thin to drain through, because a solid floor is exactly what the pressure
+ * solve uses to stop water flowing downwards.
+ *
+ * The caller must set {@link FlipFluid.drainFloor} to match: it is what keeps
+ * the opened row clear of water for the pressure solve.
  */
 export function syncSolids(
   fluid: FlipFluid,
   blockWidth: number,
   blockHeight: number,
   isSolidBlock: (x: number, y: number) => boolean,
+  openFloor = false,
 ) {
   for (let x = 0; x < blockWidth; x++) {
     for (let y = 0; y < blockHeight; y++) {
@@ -84,6 +83,12 @@ export function syncSolids(
       fluid.setSolid(fluid.width - 1 - b, j, true)
     }
   }
+  // The floor comes back out from under the world, but only from under the
+  // world: the side columns stay solid all the way down, so the grid keeps a
+  // frame on three sides and the only way out is straight down.
+  if (openFloor)
+    for (let i = CELL_BORDER; i < fluid.width - CELL_BORDER; i++)
+      for (let b = 0; b < CELL_BORDER; b++) fluid.setSolid(i, b, false)
 }
 
 /** Fill one block's worth of cells with particles at the rest packing. */

--- a/app/scripts/fluid/worldGrid.ts
+++ b/app/scripts/fluid/worldGrid.ts
@@ -29,12 +29,38 @@ export const CELLS_PER_BLOCK = 2
  */
 export const CELL_BORDER = 1
 
-/** Cells needed along an axis to hold a world this many blocks across. */
-export function cellsForBlocks(blocks: number): number {
-  return blocks * CELLS_PER_BLOCK + 2 * CELL_BORDER
+/**
+ * Open air above the world, in blocks. Simulated, never drawn.
+ *
+ * Water needs somewhere to keep its surface. A cell of water with solid
+ * directly above it is under a lid, and the solver treats it as one twice over:
+ * the face against it is pinned shut, so the pressure solve has no free surface
+ * to work against, and a solid neighbour counts as covered, so as the cell
+ * drains the drift correction reads it as submerged and pulls water back up
+ * into it. Both are right for water under a rock ceiling, which really is held
+ * up like water in a straw with a finger over the end.
+ *
+ * Neither is right for the top of the world, which is meant to be open sky. Sat
+ * straight against the border, a row of water poured in along the top would
+ * hang there and refuse to fall. One block of air is all it takes: the surface
+ * has somewhere to be, and the water pours in the way it should.
+ */
+export const HEADROOM_BLOCKS = 1
+
+/** Cells across the simulation for a world this many blocks wide. */
+export function gridWidthFor(blockWidth: number): number {
+  return blockWidth * CELLS_PER_BLOCK + 2 * CELL_BORDER
 }
 
-/** The lowest — or leftmost — cell that a block owns. */
+/** Cells up the simulation for a world this many blocks tall, sky included. */
+export function gridHeightFor(blockHeight: number): number {
+  return (blockHeight + HEADROOM_BLOCKS) * CELLS_PER_BLOCK + 2 * CELL_BORDER
+}
+
+/**
+ * The lowest — or leftmost — cell that a block owns. Passed the height of the
+ * world it gives the cell just above it, where the sky starts.
+ */
 export function firstCellOf(block: number): number {
   return block * CELLS_PER_BLOCK + CELL_BORDER
 }
@@ -83,6 +109,12 @@ export function syncSolids(
       fluid.setSolid(fluid.width - 1 - b, j, true)
     }
   }
+  // The sky is always open, whatever the blocks below it are doing. The side
+  // columns are left alone, so it is open upwards and not sideways.
+  for (let i = CELL_BORDER; i < fluid.width - CELL_BORDER; i++)
+    for (let j = firstCellOf(blockHeight); j < fluid.height - CELL_BORDER; j++)
+      fluid.setSolid(i, j, false)
+
   // The floor comes back out from under the world, but only from under the
   // world: the side columns stay solid all the way down, so the grid keeps a
   // frame on three sides and the only way out is straight down.

--- a/app/scripts/fluid/worldGrid.ts
+++ b/app/scripts/fluid/worldGrid.ts
@@ -1,0 +1,98 @@
+import type { FlipFluid } from './flipFluid'
+
+/**
+ * Where the block world and the fluid simulation meet.
+ *
+ * The solver knows nothing about blocks — it works in cells — and the block
+ * world knows nothing about the solver. This is the whole of the mapping
+ * between them, kept out of the composable so it can be tested on its own.
+ */
+
+/**
+ * How many fluid cells a block is worth along each axis. Three would give finer
+ * flow but costs more than twice as much per frame — most of the visible detail
+ * comes from where the particles are, not from how fine the grid under them is.
+ */
+export const CELLS_PER_BLOCK = 2
+
+/**
+ * A ring of solid cells around the simulation, laid *outside* the block world.
+ *
+ * The pressure solve reaches a cell's four neighbours by plain index
+ * arithmetic, so no cell that can hold water may sit on the edge of the grid;
+ * this ring is what guarantees that. It used to be carved out of the outermost
+ * blocks instead, on the grounds that half a block of rim is invisible against
+ * the terrain. It was invisible, but it was not harmless: the bottom row of the
+ * world could then only ever hold half its water, and it held it on a ledge
+ * halfway up a block that nothing was drawing. Water arriving on the floor
+ * seemed to drain away into a row that plainly had room for it.
+ */
+export const CELL_BORDER = 1
+
+/** Cells needed along an axis to hold a world this many blocks across. */
+export function cellsForBlocks(blocks: number): number {
+  return blocks * CELLS_PER_BLOCK + 2 * CELL_BORDER
+}
+
+/** The lowest — or leftmost — cell that a block owns. */
+export function firstCellOf(block: number): number {
+  return block * CELLS_PER_BLOCK + CELL_BORDER
+}
+
+/**
+ * Copy the rock into the simulation and lay the border back down around it.
+ * Every block maps onto its own square of cells and nothing else, so the floor
+ * the water rests on is exactly the floor that is drawn.
+ */
+export function syncSolids(
+  fluid: FlipFluid,
+  blockWidth: number,
+  blockHeight: number,
+  isSolidBlock: (x: number, y: number) => boolean,
+) {
+  for (let x = 0; x < blockWidth; x++) {
+    for (let y = 0; y < blockHeight; y++) {
+      const solid = isSolidBlock(x, y)
+      const i0 = firstCellOf(x)
+      const j0 = firstCellOf(y)
+      for (let ci = 0; ci < CELLS_PER_BLOCK; ci++)
+        for (let cj = 0; cj < CELLS_PER_BLOCK; cj++)
+          fluid.setSolid(i0 + ci, j0 + cj, solid)
+    }
+  }
+  for (let b = 0; b < CELL_BORDER; b++) {
+    for (let i = 0; i < fluid.width; i++) {
+      fluid.setSolid(i, b, true)
+      fluid.setSolid(i, fluid.height - 1 - b, true)
+    }
+    for (let j = 0; j < fluid.height; j++) {
+      fluid.setSolid(b, j, true)
+      fluid.setSolid(fluid.width - 1 - b, j, true)
+    }
+  }
+}
+
+/** Fill one block's worth of cells with particles at the rest packing. */
+export function fillBlock(
+  fluid: FlipFluid,
+  blockX: number,
+  blockY: number,
+  particlesPerAxis: number,
+) {
+  const step = 1 / particlesPerAxis
+  const i0 = firstCellOf(blockX)
+  const j0 = firstCellOf(blockY)
+  for (let ci = 0; ci < CELLS_PER_BLOCK; ci++) {
+    for (let cj = 0; cj < CELLS_PER_BLOCK; cj++) {
+      const cellX = i0 + ci
+      const cellY = j0 + cj
+      if (fluid.isSolid(cellX, cellY)) continue
+      for (let px = 0; px < particlesPerAxis; px++)
+        for (let py = 0; py < particlesPerAxis; py++)
+          fluid.addParticle(
+            cellX + (px + 0.5) * step,
+            cellY + (py + 0.5) * step,
+          )
+    }
+  }
+}

--- a/app/scripts/fluid/worldGrid.ts
+++ b/app/scripts/fluid/worldGrid.ts
@@ -47,22 +47,76 @@ export const CELL_BORDER = 1
  */
 export const HEADROOM_BLOCKS = 1
 
+/**
+ * Hidden rows below the world, where the next row to scroll in is built.
+ *
+ * A scroll glides the world upwards, and whatever is drawn in the strip that
+ * opens up along the bottom has to be *something*. With nothing down there it
+ * was the bottom row of blocks smeared downwards, with no water in it, and the
+ * real row appeared in its place with a jolt at the end of every glide.
+ *
+ * So the row is grown here first, a whole glide early, out of sight below the
+ * world. It is terrain and water like any other row from the moment it is made
+ * — the solver has it, water falls into it and settles in it — and the scroll
+ * simply slides it up into view. Block row -1 is where it lives.
+ */
+export const STAGING_BLOCKS = 1
+
 /** Cells across the simulation for a world this many blocks wide. */
 export function gridWidthFor(blockWidth: number): number {
   return blockWidth * CELLS_PER_BLOCK + 2 * CELL_BORDER
 }
 
-/** Cells up the simulation for a world this many blocks tall, sky included. */
+/** Cells up the simulation: the staging row, the world, and the sky. */
 export function gridHeightFor(blockHeight: number): number {
-  return (blockHeight + HEADROOM_BLOCKS) * CELLS_PER_BLOCK + 2 * CELL_BORDER
+  return (
+    (STAGING_BLOCKS + blockHeight + HEADROOM_BLOCKS) * CELLS_PER_BLOCK +
+    2 * CELL_BORDER
+  )
+}
+
+/** The leftmost cell that a column of blocks owns. */
+export function firstCellOfColumn(blockX: number): number {
+  return blockX * CELLS_PER_BLOCK + CELL_BORDER
 }
 
 /**
- * The lowest — or leftmost — cell that a block owns. Passed the height of the
- * world it gives the cell just above it, where the sky starts.
+ * The lowest cell that a row of blocks owns.
+ *
+ * Row 0 is the bottom of the *drawn* world, so the staging rows below it are
+ * at negative indices and the grid starts lower down than the world does — the
+ * two axes do not line up, and using one of these for the other was worth a
+ * whole afternoon. Passed the height of the world it gives the row just above
+ * the top block, where the sky starts.
  */
-export function firstCellOf(block: number): number {
-  return block * CELLS_PER_BLOCK + CELL_BORDER
+export function firstCellOfRow(blockY: number): number {
+  return (blockY + STAGING_BLOCKS) * CELLS_PER_BLOCK + CELL_BORDER
+}
+
+export interface FloorState {
+  /**
+   * The staging row holds real terrain rather than being the world's floor.
+   * True while scrolling, when it is about to become the bottom row and water
+   * has to be able to settle into it before it arrives.
+   *
+   * False otherwise, and then it is solid: the drawn bottom of the world has
+   * to be a floor water rests on, not a lip it quietly pours over into a row
+   * nobody can see.
+   */
+  staged?: boolean
+  /**
+   * The drain: the floor is a hole. Water is not deleted where it stands, it
+   * falls out of the bottom of the world, which is both what the valve claims
+   * to do and the only way to have it drain quickly *and* have the bottom row
+   * full of water on the way down. Deleting a band instead — however thin —
+   * leaves that band permanently dry, and a band thin enough not to show is
+   * too thin to drain through, a solid floor being exactly what the pressure
+   * solve uses to stop water falling.
+   *
+   * The caller must set {@link FlipFluid.drainFloor} to match: it is what
+   * keeps the opened row clear of water for the pressure solve.
+   */
+  openFloor?: boolean
 }
 
 /**
@@ -70,30 +124,24 @@ export function firstCellOf(block: number): number {
  * Every block maps onto its own square of cells and nothing else, so the floor
  * the water rests on is exactly the floor that is drawn.
  *
- * With `openFloor`, the border under the world is left open instead. That is
- * the drain: water is not deleted where it stands, it falls out through the
- * bottom of the world, which is both what the valve claims to do and the only
- * way to have it drain quickly *and* have the bottom row of blocks full of
- * water on the way. Deleting a band of water instead — however thin — leaves
- * that band permanently dry, and a band thin enough not to show is also too
- * thin to drain through, because a solid floor is exactly what the pressure
- * solve uses to stop water flowing downwards.
- *
- * The caller must set {@link FlipFluid.drainFloor} to match: it is what keeps
- * the opened row clear of water for the pressure solve.
+ * `isSolidBlock` is asked about the staging rows too, at negative y.
  */
 export function syncSolids(
   fluid: FlipFluid,
   blockWidth: number,
   blockHeight: number,
   isSolidBlock: (x: number, y: number) => boolean,
-  openFloor = false,
+  { staged = false, openFloor = false }: FloorState = {},
 ) {
   for (let x = 0; x < blockWidth; x++) {
-    for (let y = 0; y < blockHeight; y++) {
-      const solid = isSolidBlock(x, y)
-      const i0 = firstCellOf(x)
-      const j0 = firstCellOf(y)
+    for (let y = -STAGING_BLOCKS; y < blockHeight; y++) {
+      // A staged row is terrain like any other, drain or no drain — water
+      // leaves through the border below it, past whatever rock it happens to
+      // have. Unstaged, it is not a row at all but the floor the world stands
+      // on, and the drain is a hole in that floor.
+      const solid = y >= 0 || staged ? isSolidBlock(x, y) : !openFloor
+      const i0 = firstCellOfColumn(x)
+      const j0 = firstCellOfRow(y)
       for (let ci = 0; ci < CELLS_PER_BLOCK; ci++)
         for (let cj = 0; cj < CELLS_PER_BLOCK; cj++)
           fluid.setSolid(i0 + ci, j0 + cj, solid)
@@ -112,7 +160,11 @@ export function syncSolids(
   // The sky is always open, whatever the blocks below it are doing. The side
   // columns are left alone, so it is open upwards and not sideways.
   for (let i = CELL_BORDER; i < fluid.width - CELL_BORDER; i++)
-    for (let j = firstCellOf(blockHeight); j < fluid.height - CELL_BORDER; j++)
+    for (
+      let j = firstCellOfRow(blockHeight);
+      j < fluid.height - CELL_BORDER;
+      j++
+    )
       fluid.setSolid(i, j, false)
 
   // The floor comes back out from under the world, but only from under the
@@ -131,8 +183,8 @@ export function fillBlock(
   particlesPerAxis: number,
 ) {
   const step = 1 / particlesPerAxis
-  const i0 = firstCellOf(blockX)
-  const j0 = firstCellOf(blockY)
+  const i0 = firstCellOfColumn(blockX)
+  const j0 = firstCellOfRow(blockY)
   for (let ci = 0; ci < CELLS_PER_BLOCK; ci++) {
     for (let cj = 0; cj < CELLS_PER_BLOCK; cj++) {
       const cellX = i0 + ci

--- a/app/scripts/game.ts
+++ b/app/scripts/game.ts
@@ -22,14 +22,50 @@ import { create as createRandomizer, type RandomSeed } from 'random-seed'
  * Water goes in by the run rather than by the block, so a cave arrives wet or
  * dry rather than speckled.
  */
+/** The share of a grown row that is rock, left to its own devices. */
+const TARGET_SOLID = 0.5
+/** ...and the most it is ever allowed to be, however the odds fall. */
+const MOST_SOLID = 0.6
+
+/**
+ * Flip any block that disagrees with both its neighbours — a lone block of
+ * either kind is noise, not shape. Sweeps until it settles, reading the row as
+ * it goes rather than a snapshot of it: flipping one speck can leave its
+ * neighbour looking like another, so a single pass over a frozen copy puts
+ * back roughly as many as it takes out.
+ */
+function smoothRow(solid: boolean[]) {
+  for (let pass = 0; pass < 4; pass++) {
+    let flipped = false
+    for (let x = 1; x < solid.length - 1; x++)
+      if (solid[x] !== solid[x - 1] && solid[x] !== solid[x + 1]) {
+        solid[x] = !solid[x]!
+        flipped = true
+      }
+    if (!flipped) break
+  }
+}
+
 export function growRow(
   solidAbove: boolean[],
   random: () => number,
 ): { solid: boolean[]; water: boolean[] } {
   const width = solidAbove.length
-  // How likely a column is to be rock, by how many of the three above it are.
-  const chance = [0.1, 0.32, 0.72, 0.94]
 
+  // How likely a column is to be rock, by how many of the three above it are.
+  //
+  // Symmetric on purpose — 0.06 against 0.94, 0.30 against 0.70 — because that
+  // is what puts the balance of rock and cavern at a standstill halfway. An
+  // asymmetric table has a standstill of its own wherever the odds happen to
+  // cross, and the first cut at this one sat at about three quarters rock: the
+  // caves silted up a row at a time and a long scroll ended in solid ground.
+  const chance = [0.06, 0.3, 0.7, 0.94]
+  // ...and a nudge back towards the target from wherever the row above has got
+  // to, so a run of bad luck is leant against rather than compounded.
+  const density = solidAbove.filter(Boolean).length / width
+  const bias = (TARGET_SOLID - density) * 0.6
+
+  const aboveCount: number[] = []
   const grown: boolean[] = []
   for (let x = 0; x < width; x++) {
     let above = 0
@@ -39,21 +75,39 @@ export function growRow(
       const at = Math.min(Math.max(x + dx, 0), width - 1)
       if (solidAbove[at]) above++
     }
-    grown[x] = random() < chance[above]!
+    aboveCount[x] = above
+    grown[x] = random() < Math.min(Math.max(chance[above]! + bias, 0.02), 0.98)
   }
 
-  // Sweep until it settles, reading the row as it goes rather than a snapshot
-  // of it: flipping one speck can leave its neighbour looking like another, so
-  // a single pass over a frozen copy puts back roughly as many as it takes out.
   const solid = grown.slice()
-  for (let pass = 0; pass < 4; pass++) {
-    let flipped = false
-    for (let x = 1; x < width - 1; x++)
-      if (solid[x] !== solid[x - 1] && solid[x] !== solid[x + 1]) {
-        solid[x] = !solid[x]!
-        flipped = true
-      }
-    if (!flipped) break
+  smoothRow(solid)
+
+  // Odds and a smoothing pass are still only odds and a smoothing pass, and a
+  // world that scrolls long enough will find the run of them that closes it
+  // over for good. So there is a floor under how open a row may be. A row that
+  // comes out more rock than this is opened back up, starting at the columns
+  // with the least rock above them — which is where a cavern was already
+  // heading. Holes punched at random would read as damage; these read as the
+  // cave carrying on down.
+  //
+  // Cut past the cap rather than to it, because the smoothing that follows
+  // will close a little of it back up, and then smooth again so the openings
+  // are caverns rather than a scattering of pinholes.
+  const allowed = Math.floor(width * MOST_SOLID)
+  let rock = solid.filter(Boolean).length
+  if (rock > allowed) {
+    const target = allowed - Math.ceil(width * 0.06)
+    const key: number[] = []
+    for (let x = 0; x < width; x++) key[x] = aboveCount[x]! + random()
+    const candidates: number[] = []
+    for (let x = 0; x < width; x++) if (solid[x]) candidates.push(x)
+    candidates.sort((a, b) => key[a]! - key[b]!)
+    for (const x of candidates) {
+      if (rock <= target) break
+      solid[x] = false
+      rock--
+    }
+    smoothRow(solid)
   }
 
   const water: boolean[] = new Array(width).fill(false)

--- a/app/scripts/game.ts
+++ b/app/scripts/game.ts
@@ -2,6 +2,75 @@ import { World } from './world'
 import { BlockType, BlockNature } from './blockType'
 import { create as createRandomizer, type RandomSeed } from 'random-seed'
 
+/**
+ * Grow the row that belongs directly under the one described by `solidAbove`.
+ *
+ * `createRandomRow` scatters rock and water block by block, which is fine for
+ * the first pass of a whole world: openCaverns and connectCaverns then smooth
+ * that confetti into rooms and join them up. A row grown one at a time under a
+ * scrolling world never gets that treatment, and arrived as confetti — walls
+ * that stopped dead, caves that closed for no reason, single blocks hanging in
+ * the air.
+ *
+ * So each column takes its lead from the three blocks above it: the more rock
+ * there is over a column, the likelier that column is rock. Walls and caverns
+ * carry on downwards, and because it is only ever odds they wander as they go
+ * rather than copying the row above. A pass along the row afterwards flips any
+ * block that disagrees with both its neighbours, which closes one-block pits
+ * and knocks out one-block pillars — the same tidying openCaverns does.
+ *
+ * Water goes in by the run rather than by the block, so a cave arrives wet or
+ * dry rather than speckled.
+ */
+export function growRow(
+  solidAbove: boolean[],
+  random: () => number,
+): { solid: boolean[]; water: boolean[] } {
+  const width = solidAbove.length
+  // How likely a column is to be rock, by how many of the three above it are.
+  const chance = [0.1, 0.32, 0.72, 0.94]
+
+  const grown: boolean[] = []
+  for (let x = 0; x < width; x++) {
+    let above = 0
+    for (let dx = -1; dx <= 1; dx++) {
+      // Off the ends, read the edge column again rather than counting the void
+      // as rock, or every world would grow walls down its sides.
+      const at = Math.min(Math.max(x + dx, 0), width - 1)
+      if (solidAbove[at]) above++
+    }
+    grown[x] = random() < chance[above]!
+  }
+
+  // Sweep until it settles, reading the row as it goes rather than a snapshot
+  // of it: flipping one speck can leave its neighbour looking like another, so
+  // a single pass over a frozen copy puts back roughly as many as it takes out.
+  const solid = grown.slice()
+  for (let pass = 0; pass < 4; pass++) {
+    let flipped = false
+    for (let x = 1; x < width - 1; x++)
+      if (solid[x] !== solid[x - 1] && solid[x] !== solid[x + 1]) {
+        solid[x] = !solid[x]!
+        flipped = true
+      }
+    if (!flipped) break
+  }
+
+  const water: boolean[] = new Array(width).fill(false)
+  for (let x = 0; x < width;) {
+    if (solid[x]) {
+      x++
+      continue
+    }
+    let end = x
+    while (end < width && !solid[end]) end++
+    if (random() < 0.35) for (let i = x; i < end; i++) water[i] = true
+    x = end
+  }
+
+  return { solid, water }
+}
+
 export class Game {
   world: World
   private clockedItems: Clockable[] = []
@@ -77,9 +146,10 @@ export class Game {
       this.scrollOffset -= this.blockSize
       // remove the last row from the world
       this.world.removeRow(this.height - 1)
-      // add a new row to the bottom of the world
+      // add a new row to the bottom of the world, carrying on the shape of the
+      // one it arrives under rather than starting again from noise
       this.world.insertRow(0)
-      this.createRandomRow(0)
+      this.growRandomRow(0)
     }
   }
 
@@ -264,6 +334,30 @@ export class Game {
       for (let y = from.y; y !== to.y; y += Math.sign(to.y - from.y))
         carve(to.x, y)
       main.push(...region)
+    }
+  }
+
+  /**
+   * The row that belongs under row `aboveY`, grown but not placed. The fluid
+   * page keeps its next row out of the world entirely until it scrolls in.
+   */
+  rowBelow(aboveY: number): { solid: boolean[]; water: boolean[] } {
+    const solidAbove: boolean[] = []
+    for (let x = 0; x < this.world.width; x++)
+      solidAbove.push(
+        this.world.getBlock(x, aboveY)?.blockType.nature === BlockNature.solid,
+      )
+    return growRow(solidAbove, () => this.randomizer.random())
+  }
+
+  /** Grow row `y` from the row above it and put it in the world. */
+  growRandomRow(y: number) {
+    const { solid, water } = this.rowBelow(y + 1)
+    for (let x = 0; x < this.world.width; x++) {
+      const block = this.world.getBlock(x, y)!
+      block.blockType = this.world.getBlockType(
+        solid[x] ? 'rock' : water[x] ? 'water' : 'empty',
+      )
     }
   }
 

--- a/app/scripts/game.ts
+++ b/app/scripts/game.ts
@@ -20,9 +20,13 @@ export class Game {
   frames: number = 0
   msPerTick: number = 0
   tickMsThisSecond: number = 0
-  scrollOffset: number = 1
-  private scrollIndex: ReturnType<typeof setTimeout> | null = null
+  /** How far into the next row the scroll has glided, in pixels. */
+  scrollOffset: number = 0
+  private scrolling: boolean = false
   private randomizer: RandomSeed = createRandomizer()
+
+  /** Matches the fluid page's pace: one row of descent every two seconds. */
+  static readonly secondsPerRow = 2
 
   constructor(
     public width: number,
@@ -49,25 +53,28 @@ export class Game {
   }
 
   get isScrolling() {
-    return this.scrollIndex !== null
+    return this.scrolling
   }
   set isScrolling(value: boolean) {
-    if (value) {
-      if (this.scrollIndex !== null) return
-      this.scrollOffset = 0
-      this.scrollIndex = setInterval(this.scroll.bind(this), 100)
-    } else {
-      if (this.scrollIndex === null) return
-      clearInterval(this.scrollIndex)
-      this.scrollIndex = null
-      this.scrollOffset = 0
-    }
+    if (value === this.scrolling) return
+    this.scrolling = value
+    this.scrollOffset = 0
   }
 
-  scroll() {
-    this.scrollOffset += 1
-    if (this.scrollOffset > this.blockSize) {
-      this.scrollOffset = 0
+  /**
+   * Glide the world up by this much real time, stepping a whole row in
+   * whenever the glide passes one.
+   *
+   * Driven by the page's animation frame rather than by a timer of its own.
+   * A whole pixel every 100ms is ten discrete jumps a second however smoothly
+   * the rest of the page is painting, and that is exactly what a scroll looks
+   * like when it is described as jerky.
+   */
+  advanceScroll(seconds: number) {
+    if (!this.scrolling) return
+    this.scrollOffset += (seconds / Game.secondsPerRow) * this.blockSize
+    while (this.scrollOffset >= this.blockSize) {
+      this.scrollOffset -= this.blockSize
       // remove the last row from the world
       this.world.removeRow(this.height - 1)
       // add a new row to the bottom of the world

--- a/test/growRow.spec.ts
+++ b/test/growRow.spec.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'vitest'
+import { growRow } from '@/scripts/game'
+import { create as createRandomizer } from 'random-seed'
+
+const WIDTH = 50
+
+function seeded(seed: string) {
+  const randomizer = createRandomizer(seed)
+  return () => randomizer.random()
+}
+
+/** A row: '#' is rock, '.' is open. */
+function row(pattern: string): boolean[] {
+  return [...pattern].map((c) => c === '#')
+}
+
+function agreement(a: boolean[], b: boolean[]) {
+  let same = 0
+  for (let x = 0; x < a.length; x++) if (a[x] === b[x]) same++
+  return same / a.length
+}
+
+/** Blocks that disagree with both their neighbours — noise, not shape. */
+function specks(solid: boolean[]) {
+  let count = 0
+  for (let x = 1; x < solid.length - 1; x++)
+    if (solid[x] !== solid[x - 1] && solid[x] !== solid[x + 1]) count++
+  return count
+}
+
+describe('growing a row under a scrolling world', () => {
+  test('carries on the shape above it', () => {
+    // Half rock, half open. What comes out should look like a continuation of
+    // that, not a fresh scattering that ignores it.
+    const above = row('#'.repeat(25) + '.'.repeat(25))
+    const random = seeded('shape')
+
+    let leftRock = 0
+    let rightRock = 0
+    const runs = 40
+    for (let n = 0; n < runs; n++) {
+      const { solid } = growRow(above, random)
+      for (let x = 0; x < 25; x++) if (solid[x]) leftRock++
+      for (let x = 25; x < 50; x++) if (solid[x]) rightRock++
+    }
+    // The wall carries on down, the cavern carries on down.
+    expect(leftRock / (runs * 25)).toBeGreaterThan(0.8)
+    expect(rightRock / (runs * 25)).toBeLessThan(0.2)
+  })
+
+  test('is not a direct copy', () => {
+    const above = row(
+      '###...####..#####....###..######...##....####..###.',
+    ).slice(0, WIDTH)
+    const random = seeded('wander')
+
+    let total = 0
+    const runs = 40
+    for (let n = 0; n < runs; n++)
+      total += agreement(above, growRow(above, random).solid)
+    const average = total / runs
+
+    // It follows the row above without tracing it: close enough that walls and
+    // caverns continue, loose enough that they wander as they go.
+    expect(average).toBeGreaterThan(0.6)
+    expect(average).toBeLessThan(0.95)
+  })
+
+  test('does not arrive as confetti', () => {
+    // The old scroll called createRandomRow, which decides each block on its
+    // own and leaves single blocks hanging in the air and one-block pits in
+    // the floor. Compare against that: a coin flip per block.
+    const above = row(
+      '##..####...###..##....#####..##..####...##..###..#.',
+    ).slice(0, WIDTH)
+    const random = seeded('confetti')
+    const coinFlip = seeded('coins')
+
+    let grownSpecks = 0
+    let scatteredSpecks = 0
+    const runs = 40
+    for (let n = 0; n < runs; n++) {
+      grownSpecks += specks(growRow(above, random).solid)
+      const scattered: boolean[] = []
+      for (let x = 0; x < WIDTH; x++) scattered[x] = coinFlip() < 0.5
+      scatteredSpecks += specks(scattered)
+    }
+    expect(grownSpecks).toEqual(0)
+    expect(scatteredSpecks).toBeGreaterThan(runs * 5)
+  })
+
+  test('water arrives by the cave, not by the block', () => {
+    const above = row(
+      '#####.....#####.....#####.....#####.....#####.....',
+    ).slice(0, WIDTH)
+    const random = seeded('wet')
+
+    for (let n = 0; n < 20; n++) {
+      const { solid, water } = growRow(above, random)
+      // Water only ever goes in open blocks, and a run of open blocks is
+      // either wet end to end or dry end to end — never speckled.
+      for (let x = 0; x < WIDTH; x++) if (solid[x]) expect(water[x]).toBe(false)
+      for (let x = 1; x < WIDTH; x++)
+        if (!solid[x] && !solid[x - 1]) expect(water[x]).toEqual(water[x - 1])
+    }
+  })
+
+  test('does not grow walls down the edges of the world', () => {
+    // Reading off the end as rock would pull the outermost columns solid.
+    const above = row('.'.repeat(WIDTH))
+    const random = seeded('edges')
+
+    let edgeRock = 0
+    const runs = 60
+    for (let n = 0; n < runs; n++) {
+      const { solid } = growRow(above, random)
+      if (solid[0]) edgeRock++
+      if (solid[WIDTH - 1]) edgeRock++
+    }
+    expect(edgeRock / (runs * 2)).toBeLessThan(0.25)
+  })
+})

--- a/test/growRow.spec.ts
+++ b/test/growRow.spec.ts
@@ -105,18 +105,54 @@ describe('growing a row under a scrolling world', () => {
     }
   })
 
+  test('stays open however long the world scrolls', () => {
+    // Row grown from row grown from row, the way a scroll actually uses this.
+    // The first cut at the odds had its standstill at about three quarters
+    // rock, so the caverns silted up a row at a time and a long scroll ended
+    // in solid ground with nowhere for water to go.
+    for (const start of [
+      '#'.repeat(WIDTH),
+      '.'.repeat(WIDTH),
+      '#.'.repeat(25),
+    ]) {
+      const random = seeded(`long-${start.length}-${start[0]}`)
+      let above = row(start)
+      let worst = 1
+      let total = 0
+      const rows = 400
+      for (let n = 0; n < rows; n++) {
+        above = growRow(above, random).solid
+        const open = above.filter((s) => !s).length / WIDTH
+        worst = Math.min(worst, open)
+        total += open
+      }
+      // Never closes over, wherever it started...
+      expect(worst).toBeGreaterThanOrEqual(0.4)
+      // ...and settles around half and half rather than drifting to one end.
+      const average = total / rows
+      expect(average).toBeGreaterThan(0.42)
+      expect(average).toBeLessThan(0.62)
+    }
+  })
+
   test('does not grow walls down the edges of the world', () => {
-    // Reading off the end as rock would pull the outermost columns solid.
-    const above = row('.'.repeat(WIDTH))
+    // Reading off the end as rock would pull the outermost columns solid. The
+    // test is the edges against the middle, not against a number: whatever the
+    // world is doing overall, the sides should be doing the same thing.
     const random = seeded('edges')
+    let above = row('#.'.repeat(25))
 
     let edgeRock = 0
-    const runs = 60
+    let middleRock = 0
+    const runs = 200
     for (let n = 0; n < runs; n++) {
-      const { solid } = growRow(above, random)
-      if (solid[0]) edgeRock++
-      if (solid[WIDTH - 1]) edgeRock++
+      above = growRow(above, random).solid
+      if (above[0]) edgeRock++
+      if (above[WIDTH - 1]) edgeRock++
+      for (let x = 10; x < 40; x++) if (above[x]) middleRock++
     }
-    expect(edgeRock / (runs * 2)).toBeLessThan(0.25)
+    const edges = edgeRock / (runs * 2)
+    const middle = middleRock / (runs * 30)
+    expect(Math.abs(edges - middle)).toBeLessThan(0.12)
   })
 })

--- a/test/worldGrid.spec.ts
+++ b/test/worldGrid.spec.ts
@@ -4,14 +4,10 @@ import {
   CELLS_PER_BLOCK,
   CELL_BORDER,
   cellsForBlocks,
-  drainLine,
   fillBlock,
   firstCellOf,
   syncSolids,
 } from '@/scripts/fluid/worldGrid'
-
-/** Every particle fineness the settings menu offers: n packs n² into a cell. */
-const PARTICLES_PER_AXIS = [1, 2, 3, 4]
 
 const BLOCKS_WIDE = 8
 const BLOCKS_TALL = 6
@@ -95,33 +91,69 @@ describe('world grid', () => {
     expect(fluid.count).toEqual(full * 4)
   })
 
-  test('an open drain takes water at the floor, not a row above it', () => {
-    for (const perAxis of PARTICLES_PER_AXIS) {
-      const line = drainLine(1 / perAxis)
-      // Above the floor, or the last of the water never leaves...
-      expect(line).toBeGreaterThan(firstCellOf(0))
-      // ...and inside the bottom row of blocks, or that row is a dead band
-      // that water is deleted from before it is ever drawn there. This was
-      // the bug: the line sat at firstCellOf(1) + 0.5, a whole block row up,
-      // so opening the drain emptied the bottom row rather than draining it.
-      expect(line).toBeLessThan(firstCellOf(1))
+  test('an open floor opens under the world and nowhere else', () => {
+    const fluid = makeWorld()
+    syncSolids(fluid, BLOCKS_WIDE, BLOCKS_TALL, () => false, true)
+
+    // Straight down is the only way out: the floor under the blocks is open...
+    for (let i = CELL_BORDER; i < fluid.width - CELL_BORDER; i++)
+      expect(fluid.isSolid(i, 0)).toBe(false)
+    // ...and the rest of the frame is untouched, corners included, so no cell
+    // the pressure solve can reach ever sits on the edge of the grid.
+    expect(fluid.isSolid(0, 0)).toBe(true)
+    expect(fluid.isSolid(fluid.width - 1, 0)).toBe(true)
+    for (let j = 0; j < fluid.height; j++) {
+      expect(fluid.isSolid(0, j)).toBe(true)
+      expect(fluid.isSolid(fluid.width - 1, j)).toBe(true)
     }
+    for (let i = 0; i < fluid.width; i++)
+      expect(fluid.isSolid(i, fluid.height - 1)).toBe(true)
+
+    // ...and it closes again.
+    syncSolids(fluid, BLOCKS_WIDE, BLOCKS_TALL, () => false, false)
+    for (let i = 0; i < fluid.width; i++) expect(fluid.isSolid(i, 0)).toBe(true)
   })
 
-  test('a settled body of water reaches down past the drain line', () => {
-    // The line is only useful if water actually gets to it. Pour a column in
-    // and let it settle onto the floor: the bottom of it has to end up below
-    // the line, or an open drain would sit there doing nothing.
-    const perAxis = 4
+  test('an open floor empties the world, and quickly', () => {
     const fluid = makeWorld()
-    for (let y = 0; y < 3; y++) fillBlock(fluid, 3, y, perAxis)
+    for (let x = 0; x < BLOCKS_WIDE; x++)
+      for (let y = 0; y < 3; y++) fillBlock(fluid, x, y, 4)
+    const poured = fluid.count
+    expect(poured).toBeGreaterThan(1000)
 
-    for (let i = 0; i < 300; i++) fluid.step(1 / 60)
+    // Shut, the floor holds every drop.
+    for (let i = 0; i < 120; i++) fluid.step(1 / 60)
+    expect(fluid.count).toEqual(poured)
 
-    let lowest = Infinity
-    for (let i = 0; i < fluid.count; i++)
-      lowest = Math.min(lowest, fluid.py[i]!)
-    expect(lowest).toBeLessThan(drainLine(1 / perAxis))
+    // Open, it goes — under its own weight, rather than being deleted where it
+    // stands. Two seconds is the pace this is held to: draining by nibbling a
+    // thin band off the bottom took the better part of a minute, and widening
+    // that band is what left the bottom row dry.
+    syncSolids(fluid, BLOCKS_WIDE, BLOCKS_TALL, () => false, true)
+    fluid.drainFloor = true
+    for (let i = 0; i < 120; i++) fluid.step(1 / 60)
+    expect(fluid.count).toEqual(0)
+  })
+
+  test('water crosses the bottom row on its way out of an open floor', () => {
+    const fluid = makeWorld()
+    for (let x = 0; x < BLOCKS_WIDE; x++)
+      for (let y = 2; y < 5; y++) fillBlock(fluid, x, y, 4)
+    syncSolids(fluid, BLOCKS_WIDE, BLOCKS_TALL, () => false, true)
+    fluid.drainFloor = true
+
+    // The water starts two rows up, so it has to cross the bottom row to
+    // leave, and it has to be *in* that row while it does. The old drain
+    // deleted it a row early, so the bottom row was never water at all.
+    let mostInBottomRow = 0
+    for (let i = 0; i < 90; i++) {
+      fluid.step(1 / 60)
+      let here = 0
+      for (let p = 0; p < fluid.count; p++)
+        if (fluid.py[p]! < firstCellOf(1)) here++
+      mostInBottomRow = Math.max(mostInBottomRow, here)
+    }
+    expect(mostInBottomRow).toBeGreaterThan(100)
   })
 
   test('water poured into the bottom row stays in the bottom row', () => {

--- a/test/worldGrid.spec.ts
+++ b/test/worldGrid.spec.ts
@@ -4,10 +4,14 @@ import {
   CELLS_PER_BLOCK,
   CELL_BORDER,
   cellsForBlocks,
+  drainLine,
   fillBlock,
   firstCellOf,
   syncSolids,
 } from '@/scripts/fluid/worldGrid'
+
+/** Every particle fineness the settings menu offers: n packs n² into a cell. */
+const PARTICLES_PER_AXIS = [1, 2, 3, 4]
 
 const BLOCKS_WIDE = 8
 const BLOCKS_TALL = 6
@@ -89,6 +93,35 @@ describe('world grid', () => {
     fillBlock(fluid, 0, 2, perAxis)
     fillBlock(fluid, BLOCKS_WIDE - 1, 2, perAxis)
     expect(fluid.count).toEqual(full * 4)
+  })
+
+  test('an open drain takes water at the floor, not a row above it', () => {
+    for (const perAxis of PARTICLES_PER_AXIS) {
+      const line = drainLine(1 / perAxis)
+      // Above the floor, or the last of the water never leaves...
+      expect(line).toBeGreaterThan(firstCellOf(0))
+      // ...and inside the bottom row of blocks, or that row is a dead band
+      // that water is deleted from before it is ever drawn there. This was
+      // the bug: the line sat at firstCellOf(1) + 0.5, a whole block row up,
+      // so opening the drain emptied the bottom row rather than draining it.
+      expect(line).toBeLessThan(firstCellOf(1))
+    }
+  })
+
+  test('a settled body of water reaches down past the drain line', () => {
+    // The line is only useful if water actually gets to it. Pour a column in
+    // and let it settle onto the floor: the bottom of it has to end up below
+    // the line, or an open drain would sit there doing nothing.
+    const perAxis = 4
+    const fluid = makeWorld()
+    for (let y = 0; y < 3; y++) fillBlock(fluid, 3, y, perAxis)
+
+    for (let i = 0; i < 300; i++) fluid.step(1 / 60)
+
+    let lowest = Infinity
+    for (let i = 0; i < fluid.count; i++)
+      lowest = Math.min(lowest, fluid.py[i]!)
+    expect(lowest).toBeLessThan(drainLine(1 / perAxis))
   })
 
   test('water poured into the bottom row stays in the bottom row', () => {

--- a/test/worldGrid.spec.ts
+++ b/test/worldGrid.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'vitest'
+import { FlipFluid } from '@/scripts/fluid/flipFluid'
+import {
+  CELLS_PER_BLOCK,
+  CELL_BORDER,
+  cellsForBlocks,
+  fillBlock,
+  firstCellOf,
+  syncSolids,
+} from '@/scripts/fluid/worldGrid'
+
+const BLOCKS_WIDE = 8
+const BLOCKS_TALL = 6
+
+/** A world of open blocks unless `rock` says otherwise. */
+function makeWorld(rock: (x: number, y: number) => boolean = () => false) {
+  const fluid = new FlipFluid({
+    width: cellsForBlocks(BLOCKS_WIDE),
+    height: cellsForBlocks(BLOCKS_TALL),
+    maxParticles: 20000,
+  })
+  syncSolids(fluid, BLOCKS_WIDE, BLOCKS_TALL, rock)
+  return fluid
+}
+
+describe('world grid', () => {
+  test('every block gets its own square of cells and nothing else', () => {
+    const fluid = makeWorld()
+    expect(fluid.width).toEqual(BLOCKS_WIDE * CELLS_PER_BLOCK + 2 * CELL_BORDER)
+    expect(fluid.height).toEqual(
+      BLOCKS_TALL * CELLS_PER_BLOCK + 2 * CELL_BORDER,
+    )
+
+    // Blocks tile the interior exactly: the first cell of one block is the one
+    // after the last cell of the block below it.
+    expect(firstCellOf(0)).toEqual(CELL_BORDER)
+    expect(firstCellOf(BLOCKS_TALL - 1) + CELLS_PER_BLOCK).toEqual(
+      fluid.height - CELL_BORDER,
+    )
+  })
+
+  test('the solid border sits outside the blocks, not inside them', () => {
+    const fluid = makeWorld()
+
+    // Every cell of every block of an empty world is open — including the
+    // bottom row, which used to have its lower half taken by the border and so
+    // could only ever hold half a block of water, resting on a ledge halfway up
+    // a block that nothing was drawing.
+    for (let x = 0; x < BLOCKS_WIDE; x++)
+      for (let y = 0; y < BLOCKS_TALL; y++)
+        for (let ci = 0; ci < CELLS_PER_BLOCK; ci++)
+          for (let cj = 0; cj < CELLS_PER_BLOCK; cj++)
+            expect(
+              fluid.isSolid(firstCellOf(x) + ci, firstCellOf(y) + cj),
+            ).toBe(false)
+
+    // ...and the ring around them is solid, which is what lets the pressure
+    // solve reach a water cell's four neighbours without a bounds check.
+    for (let i = 0; i < fluid.width; i++) {
+      expect(fluid.isSolid(i, 0)).toBe(true)
+      expect(fluid.isSolid(i, fluid.height - 1)).toBe(true)
+    }
+    for (let j = 0; j < fluid.height; j++) {
+      expect(fluid.isSolid(0, j)).toBe(true)
+      expect(fluid.isSolid(fluid.width - 1, j)).toBe(true)
+    }
+  })
+
+  test('rock lands on the right cells', () => {
+    // One block of rock, in the bottom left corner, where an off-by-one against
+    // the border would be easiest to miss.
+    const fluid = makeWorld((x, y) => x === 0 && y === 0)
+    expect(fluid.isSolid(firstCellOf(0), firstCellOf(0))).toBe(true)
+    expect(fluid.isSolid(firstCellOf(1), firstCellOf(0))).toBe(false)
+    expect(fluid.isSolid(firstCellOf(0), firstCellOf(1))).toBe(false)
+  })
+
+  test('a block of water is worth the same wherever it is poured', () => {
+    const fluid = makeWorld()
+    const perAxis = 4
+    const full = CELLS_PER_BLOCK * CELLS_PER_BLOCK * perAxis * perAxis
+
+    // The bottom row is the one that mattered: the row a scroll brings in is
+    // poured there, and it used to arrive half empty.
+    fillBlock(fluid, 3, 0, perAxis)
+    expect(fluid.count).toEqual(full)
+
+    fillBlock(fluid, 3, BLOCKS_TALL - 1, perAxis)
+    fillBlock(fluid, 0, 2, perAxis)
+    fillBlock(fluid, BLOCKS_WIDE - 1, 2, perAxis)
+    expect(fluid.count).toEqual(full * 4)
+  })
+
+  test('water poured into the bottom row stays in the bottom row', () => {
+    const fluid = makeWorld()
+    for (let x = 0; x < BLOCKS_WIDE; x++) fillBlock(fluid, x, 0, 4)
+    const poured = fluid.count
+
+    for (let i = 0; i < 300; i++) fluid.step(1 / 60)
+
+    // None of it leaks away, and it settles filling the block row it was poured
+    // into rather than half of it.
+    expect(fluid.count).toEqual(poured)
+    let top = 0
+    for (let i = 0; i < fluid.count; i++) top = Math.max(top, fluid.py[i]!)
+    expect(top).toBeGreaterThan(firstCellOf(0) + CELLS_PER_BLOCK - 0.5)
+    expect(top).toBeLessThan(firstCellOf(1) + CELLS_PER_BLOCK)
+  })
+})

--- a/test/worldGrid.spec.ts
+++ b/test/worldGrid.spec.ts
@@ -4,93 +4,66 @@ import {
   CELLS_PER_BLOCK,
   CELL_BORDER,
   HEADROOM_BLOCKS,
+  STAGING_BLOCKS,
   fillBlock,
-  firstCellOf,
+  firstCellOfColumn,
+  firstCellOfRow,
   gridHeightFor,
   gridWidthFor,
   syncSolids,
+  type FloorState,
 } from '@/scripts/fluid/worldGrid'
 
 const BLOCKS_WIDE = 8
 const BLOCKS_TALL = 6
 
 /** A world of open blocks unless `rock` says otherwise. */
-function makeWorld(rock: (x: number, y: number) => boolean = () => false) {
+function makeWorld(
+  rock: (x: number, y: number) => boolean = () => false,
+  floor: FloorState = {},
+) {
   const fluid = new FlipFluid({
     width: gridWidthFor(BLOCKS_WIDE),
     height: gridHeightFor(BLOCKS_TALL),
     maxParticles: 20000,
   })
-  syncSolids(fluid, BLOCKS_WIDE, BLOCKS_TALL, rock)
+  syncSolids(fluid, BLOCKS_WIDE, BLOCKS_TALL, rock, floor)
   return fluid
 }
 
-/** The highest any particle has got to, in cells. */
+/** The highest, and lowest, any particle has got to, in cells. */
 function highest(fluid: FlipFluid) {
   let top = 0
   for (let i = 0; i < fluid.count; i++) top = Math.max(top, fluid.py[i]!)
   return top
 }
+function lowest(fluid: FlipFluid) {
+  let bottom = Infinity
+  for (let i = 0; i < fluid.count; i++) bottom = Math.min(bottom, fluid.py[i]!)
+  return bottom
+}
 
 describe('world grid', () => {
-  test('every block gets its own square of cells and nothing else', () => {
+  test('the grid is the world, plus somewhere to stage, sky and a border', () => {
     const fluid = makeWorld()
     expect(fluid.width).toEqual(BLOCKS_WIDE * CELLS_PER_BLOCK + 2 * CELL_BORDER)
-
-    // Blocks tile the interior exactly: the first cell of one block is the one
-    // after the last cell of the block below it.
-    expect(firstCellOf(0)).toEqual(CELL_BORDER)
-    // Above the top block is sky, and above that the border.
     expect(fluid.height).toEqual(
-      firstCellOf(BLOCKS_TALL) +
+      firstCellOfRow(BLOCKS_TALL) +
         HEADROOM_BLOCKS * CELLS_PER_BLOCK +
         CELL_BORDER,
     )
+
+    // Block 0 is the bottom of the *drawn* world. Below it are the staging
+    // rows and then the border; above the top block is sky.
+    expect(firstCellOfRow(0)).toEqual(
+      STAGING_BLOCKS * CELLS_PER_BLOCK + CELL_BORDER,
+    )
+    expect(firstCellOfRow(-STAGING_BLOCKS)).toEqual(CELL_BORDER)
+    // Blocks tile exactly: one starts where the one below it ends.
+    expect(firstCellOfRow(1)).toEqual(firstCellOfRow(0) + CELLS_PER_BLOCK)
   })
 
-  test('the sky above the world is open air', () => {
-    // Rock everywhere it is allowed to put rock; the sky is not one of those
-    // places, whatever the blocks below it say.
-    const fluid = makeWorld(() => true)
-    for (let i = CELL_BORDER; i < fluid.width - CELL_BORDER; i++) {
-      for (
-        let j = firstCellOf(BLOCKS_TALL);
-        j < fluid.height - CELL_BORDER;
-        j++
-      )
-        expect(fluid.isSolid(i, j)).toBe(false)
-      // The lid is still up there, one block higher than it used to be.
-      expect(fluid.isSolid(i, fluid.height - 1)).toBe(true)
-    }
-    // Open upwards, not sideways.
-    for (let j = 0; j < fluid.height; j++) {
-      expect(fluid.isSolid(0, j)).toBe(true)
-      expect(fluid.isSolid(fluid.width - 1, j)).toBe(true)
-    }
-  })
-
-  test('water poured in along the top falls instead of hanging from the sky', () => {
-    // The bug this guards: sat straight against a solid border, the top row of
-    // water is under a lid. Its top face is pinned shut so the pressure solve
-    // has no free surface there, and a solid neighbour counts as covered, so
-    // the drift correction reads the draining cell as submerged and pulls the
-    // water back up into it. The row hung there and would not fall.
-    const fluid = makeWorld()
-    for (let x = 0; x < BLOCKS_WIDE; x++)
-      fillBlock(fluid, x, BLOCKS_TALL - 1, 4)
-    const poured = fluid.count
-    expect(highest(fluid)).toBeGreaterThan(firstCellOf(BLOCKS_TALL - 1))
-
-    // One second is many times over what it takes to fall this far.
-    for (let i = 0; i < 60; i++) fluid.step(1 / 60)
-
-    expect(fluid.count).toEqual(poured)
-    // All of it poured in as one block row's worth per column, so once it has
-    // landed it stands about a block deep and nothing is left up top.
-    expect(highest(fluid)).toBeLessThan(firstCellOf(2))
-  })
-
-  test('the solid border sits outside the blocks, not inside them', () => {
+  test('the border sits outside the blocks, not inside them', () => {
     const fluid = makeWorld()
 
     // Every cell of every block of an empty world is open — including the
@@ -102,7 +75,7 @@ describe('world grid', () => {
         for (let ci = 0; ci < CELLS_PER_BLOCK; ci++)
           for (let cj = 0; cj < CELLS_PER_BLOCK; cj++)
             expect(
-              fluid.isSolid(firstCellOf(x) + ci, firstCellOf(y) + cj),
+              fluid.isSolid(firstCellOfColumn(x) + ci, firstCellOfRow(y) + cj),
             ).toBe(false)
 
     // ...and the ring around them is solid, which is what lets the pressure
@@ -119,50 +92,111 @@ describe('world grid', () => {
 
   test('rock lands on the right cells', () => {
     // One block of rock, in the bottom left corner, where an off-by-one against
-    // the border would be easiest to miss.
+    // the border or the staging row would be easiest to miss.
     const fluid = makeWorld((x, y) => x === 0 && y === 0)
-    expect(fluid.isSolid(firstCellOf(0), firstCellOf(0))).toBe(true)
-    expect(fluid.isSolid(firstCellOf(1), firstCellOf(0))).toBe(false)
-    expect(fluid.isSolid(firstCellOf(0), firstCellOf(1))).toBe(false)
+    expect(fluid.isSolid(firstCellOfColumn(0), firstCellOfRow(0))).toBe(true)
+    expect(fluid.isSolid(firstCellOfColumn(1), firstCellOfRow(0))).toBe(false)
+    expect(fluid.isSolid(firstCellOfColumn(0), firstCellOfRow(1))).toBe(false)
   })
 
-  test('a block of water is worth the same wherever it is poured', () => {
-    const fluid = makeWorld()
-    const perAxis = 4
-    const full = CELLS_PER_BLOCK * CELLS_PER_BLOCK * perAxis * perAxis
-
-    // The bottom row is the one that mattered: the row a scroll brings in is
-    // poured there, and it used to arrive half empty.
-    fillBlock(fluid, 3, 0, perAxis)
-    expect(fluid.count).toEqual(full)
-
-    fillBlock(fluid, 3, BLOCKS_TALL - 1, perAxis)
-    fillBlock(fluid, 0, 2, perAxis)
-    fillBlock(fluid, BLOCKS_WIDE - 1, 2, perAxis)
-    expect(fluid.count).toEqual(full * 4)
+  test('the sky above the world is open air', () => {
+    // Rock everywhere it is allowed to put rock; the sky is not one of those
+    // places, whatever the blocks below it say.
+    const fluid = makeWorld(() => true)
+    for (let i = CELL_BORDER; i < fluid.width - CELL_BORDER; i++) {
+      for (
+        let j = firstCellOfRow(BLOCKS_TALL);
+        j < fluid.height - CELL_BORDER;
+        j++
+      )
+        expect(fluid.isSolid(i, j)).toBe(false)
+      expect(fluid.isSolid(i, fluid.height - 1)).toBe(true)
+    }
+    // Open upwards, not sideways.
+    for (let j = 0; j < fluid.height; j++) {
+      expect(fluid.isSolid(0, j)).toBe(true)
+      expect(fluid.isSolid(fluid.width - 1, j)).toBe(true)
+    }
   })
 
-  test('an open floor opens under the world and nowhere else', () => {
+  test('water poured in along the top falls instead of hanging from the sky', () => {
+    // Sat straight against a solid border, the top row of water is under a lid:
+    // its top face is pinned shut so the pressure solve has no free surface
+    // there, and a solid neighbour counts as covered, so the drift correction
+    // reads the draining cell as submerged and pulls the water back up into it.
+    // The row hung there and would not fall.
     const fluid = makeWorld()
-    syncSolids(fluid, BLOCKS_WIDE, BLOCKS_TALL, () => false, true)
+    for (let x = 0; x < BLOCKS_WIDE; x++)
+      fillBlock(fluid, x, BLOCKS_TALL - 1, 4)
+    const poured = fluid.count
+    expect(highest(fluid)).toBeGreaterThan(firstCellOfRow(BLOCKS_TALL - 1))
 
-    // Straight down is the only way out: the floor under the blocks is open...
+    for (let i = 0; i < 60; i++) fluid.step(1 / 60)
+
+    expect(fluid.count).toEqual(poured)
+    expect(highest(fluid)).toBeLessThan(firstCellOfRow(2))
+  })
+
+  test('an unstaged world stands on a floor, not over a hole', () => {
+    // Nothing is scrolling, so the row below the world is not a row at all —
+    // it is the floor the drawn world rests on. Water reaching the bottom has
+    // to stay there and be seen, not pour quietly into a row nobody can see.
+    const fluid = makeWorld()
+    for (let x = 0; x < BLOCKS_WIDE; x++)
+      for (let cj = 0; cj < CELLS_PER_BLOCK; cj++)
+        expect(
+          fluid.isSolid(firstCellOfColumn(x), firstCellOfRow(-1) + cj),
+        ).toBe(true)
+
+    for (let x = 0; x < BLOCKS_WIDE; x++) fillBlock(fluid, x, 0, 4)
+    const poured = fluid.count
+    for (let i = 0; i < 180; i++) fluid.step(1 / 60)
+
+    expect(fluid.count).toEqual(poured)
+    expect(lowest(fluid)).toBeGreaterThanOrEqual(firstCellOfRow(0))
+  })
+
+  test('a staged row is terrain, and water settles into it before it arrives', () => {
+    // Scrolling: the row below the world is the one about to slide into view,
+    // and it has to behave like a row for the whole glide it spends hidden —
+    // that is the point of building it early.
+    const staging = [true, false, true, false, false, true, false, true]
+    const fluid = makeWorld((x, y) => (y < 0 ? staging[x]! : false), {
+      staged: true,
+    })
+    for (let x = 0; x < BLOCKS_WIDE; x++)
+      expect(fluid.isSolid(firstCellOfColumn(x), firstCellOfRow(-1))).toBe(
+        staging[x],
+      )
+
+    // Water poured into the open blocks of it stays in it and settles.
+    for (let x = 0; x < BLOCKS_WIDE; x++)
+      if (!staging[x]) fillBlock(fluid, x, -1, 4)
+    const poured = fluid.count
+    expect(poured).toBeGreaterThan(0)
+
+    for (let i = 0; i < 120; i++) fluid.step(1 / 60)
+
+    expect(fluid.count).toEqual(poured)
+    expect(lowest(fluid)).toBeGreaterThan(firstCellOfRow(-STAGING_BLOCKS))
+  })
+
+  test('an open floor opens below the world and nowhere else', () => {
+    const fluid = makeWorld(() => false, { openFloor: true })
+
+    // Straight down is the only way out: the staging row and the border under
+    // it are both open...
     for (let i = CELL_BORDER; i < fluid.width - CELL_BORDER; i++)
-      expect(fluid.isSolid(i, 0)).toBe(false)
-    // ...and the rest of the frame is untouched, corners included, so no cell
-    // the pressure solve can reach sits on the edge of the grid.
-    expect(fluid.isSolid(0, 0)).toBe(true)
-    expect(fluid.isSolid(fluid.width - 1, 0)).toBe(true)
+      for (let j = 0; j < firstCellOfRow(0); j++)
+        expect(fluid.isSolid(i, j)).toBe(false)
+    // ...and the side columns are untouched, corners included, so no cell the
+    // pressure solve can reach sits on the edge of the grid.
     for (let j = 0; j < fluid.height; j++) {
       expect(fluid.isSolid(0, j)).toBe(true)
       expect(fluid.isSolid(fluid.width - 1, j)).toBe(true)
     }
     for (let i = 0; i < fluid.width; i++)
       expect(fluid.isSolid(i, fluid.height - 1)).toBe(true)
-
-    // ...and it closes again.
-    syncSolids(fluid, BLOCKS_WIDE, BLOCKS_TALL, () => false, false)
-    for (let i = 0; i < fluid.width; i++) expect(fluid.isSolid(i, 0)).toBe(true)
   })
 
   test('an open floor empties the world, and quickly', () => {
@@ -180,17 +214,32 @@ describe('world grid', () => {
     // stands. Two seconds is the pace this is held to: draining by nibbling a
     // thin band off the bottom took the better part of a minute, and widening
     // that band is what left the bottom row dry.
-    syncSolids(fluid, BLOCKS_WIDE, BLOCKS_TALL, () => false, true)
+    syncSolids(fluid, BLOCKS_WIDE, BLOCKS_TALL, () => false, {
+      openFloor: true,
+    })
     fluid.drainFloor = true
     for (let i = 0; i < 120; i++) fluid.step(1 / 60)
     expect(fluid.count).toEqual(0)
   })
 
+  test('an open floor drains a scrolling world too', () => {
+    // The valve and the scroll are independent: a staged row below the world
+    // is terrain, and water leaves past it through the border underneath.
+    const fluid = makeWorld(() => false, { staged: true, openFloor: true })
+    for (let x = 0; x < BLOCKS_WIDE; x++)
+      for (let y = 0; y < 3; y++) fillBlock(fluid, x, y, 4)
+    expect(fluid.count).toBeGreaterThan(1000)
+    fluid.drainFloor = true
+
+    for (let i = 0; i < 180; i++) fluid.step(1 / 60)
+
+    expect(fluid.count).toEqual(0)
+  })
+
   test('water crosses the bottom row on its way out of an open floor', () => {
-    const fluid = makeWorld()
+    const fluid = makeWorld(() => false, { openFloor: true })
     for (let x = 0; x < BLOCKS_WIDE; x++)
       for (let y = 2; y < 5; y++) fillBlock(fluid, x, y, 4)
-    syncSolids(fluid, BLOCKS_WIDE, BLOCKS_TALL, () => false, true)
     fluid.drainFloor = true
 
     // The water starts two rows up, so it has to cross the bottom row to
@@ -201,10 +250,28 @@ describe('world grid', () => {
       fluid.step(1 / 60)
       let here = 0
       for (let p = 0; p < fluid.count; p++)
-        if (fluid.py[p]! < firstCellOf(1)) here++
+        if (
+          fluid.py[p]! >= firstCellOfRow(0) &&
+          fluid.py[p]! < firstCellOfRow(1)
+        )
+          here++
       mostInBottomRow = Math.max(mostInBottomRow, here)
     }
     expect(mostInBottomRow).toBeGreaterThan(100)
+  })
+
+  test('a block of water is worth the same wherever it is poured', () => {
+    const fluid = makeWorld()
+    const perAxis = 4
+    const full = CELLS_PER_BLOCK * CELLS_PER_BLOCK * perAxis * perAxis
+
+    fillBlock(fluid, 3, 0, perAxis)
+    expect(fluid.count).toEqual(full)
+
+    fillBlock(fluid, 3, BLOCKS_TALL - 1, perAxis)
+    fillBlock(fluid, 0, 2, perAxis)
+    fillBlock(fluid, BLOCKS_WIDE - 1, 2, perAxis)
+    expect(fluid.count).toEqual(full * 4)
   })
 
   test('water poured into the bottom row stays in the bottom row', () => {
@@ -217,9 +284,9 @@ describe('world grid', () => {
     // None of it leaks away, and it settles filling the block row it was poured
     // into rather than half of it.
     expect(fluid.count).toEqual(poured)
-    let top = 0
-    for (let i = 0; i < fluid.count; i++) top = Math.max(top, fluid.py[i]!)
-    expect(top).toBeGreaterThan(firstCellOf(0) + CELLS_PER_BLOCK - 0.5)
-    expect(top).toBeLessThan(firstCellOf(1) + CELLS_PER_BLOCK)
+    expect(highest(fluid)).toBeGreaterThan(
+      firstCellOfRow(0) + CELLS_PER_BLOCK - 0.5,
+    )
+    expect(highest(fluid)).toBeLessThan(firstCellOfRow(1) + CELLS_PER_BLOCK)
   })
 })

--- a/test/worldGrid.spec.ts
+++ b/test/worldGrid.spec.ts
@@ -3,9 +3,11 @@ import { FlipFluid } from '@/scripts/fluid/flipFluid'
 import {
   CELLS_PER_BLOCK,
   CELL_BORDER,
-  cellsForBlocks,
+  HEADROOM_BLOCKS,
   fillBlock,
   firstCellOf,
+  gridHeightFor,
+  gridWidthFor,
   syncSolids,
 } from '@/scripts/fluid/worldGrid'
 
@@ -15,28 +17,77 @@ const BLOCKS_TALL = 6
 /** A world of open blocks unless `rock` says otherwise. */
 function makeWorld(rock: (x: number, y: number) => boolean = () => false) {
   const fluid = new FlipFluid({
-    width: cellsForBlocks(BLOCKS_WIDE),
-    height: cellsForBlocks(BLOCKS_TALL),
+    width: gridWidthFor(BLOCKS_WIDE),
+    height: gridHeightFor(BLOCKS_TALL),
     maxParticles: 20000,
   })
   syncSolids(fluid, BLOCKS_WIDE, BLOCKS_TALL, rock)
   return fluid
 }
 
+/** The highest any particle has got to, in cells. */
+function highest(fluid: FlipFluid) {
+  let top = 0
+  for (let i = 0; i < fluid.count; i++) top = Math.max(top, fluid.py[i]!)
+  return top
+}
+
 describe('world grid', () => {
   test('every block gets its own square of cells and nothing else', () => {
     const fluid = makeWorld()
     expect(fluid.width).toEqual(BLOCKS_WIDE * CELLS_PER_BLOCK + 2 * CELL_BORDER)
-    expect(fluid.height).toEqual(
-      BLOCKS_TALL * CELLS_PER_BLOCK + 2 * CELL_BORDER,
-    )
 
     // Blocks tile the interior exactly: the first cell of one block is the one
     // after the last cell of the block below it.
     expect(firstCellOf(0)).toEqual(CELL_BORDER)
-    expect(firstCellOf(BLOCKS_TALL - 1) + CELLS_PER_BLOCK).toEqual(
-      fluid.height - CELL_BORDER,
+    // Above the top block is sky, and above that the border.
+    expect(fluid.height).toEqual(
+      firstCellOf(BLOCKS_TALL) +
+        HEADROOM_BLOCKS * CELLS_PER_BLOCK +
+        CELL_BORDER,
     )
+  })
+
+  test('the sky above the world is open air', () => {
+    // Rock everywhere it is allowed to put rock; the sky is not one of those
+    // places, whatever the blocks below it say.
+    const fluid = makeWorld(() => true)
+    for (let i = CELL_BORDER; i < fluid.width - CELL_BORDER; i++) {
+      for (
+        let j = firstCellOf(BLOCKS_TALL);
+        j < fluid.height - CELL_BORDER;
+        j++
+      )
+        expect(fluid.isSolid(i, j)).toBe(false)
+      // The lid is still up there, one block higher than it used to be.
+      expect(fluid.isSolid(i, fluid.height - 1)).toBe(true)
+    }
+    // Open upwards, not sideways.
+    for (let j = 0; j < fluid.height; j++) {
+      expect(fluid.isSolid(0, j)).toBe(true)
+      expect(fluid.isSolid(fluid.width - 1, j)).toBe(true)
+    }
+  })
+
+  test('water poured in along the top falls instead of hanging from the sky', () => {
+    // The bug this guards: sat straight against a solid border, the top row of
+    // water is under a lid. Its top face is pinned shut so the pressure solve
+    // has no free surface there, and a solid neighbour counts as covered, so
+    // the drift correction reads the draining cell as submerged and pulls the
+    // water back up into it. The row hung there and would not fall.
+    const fluid = makeWorld()
+    for (let x = 0; x < BLOCKS_WIDE; x++)
+      fillBlock(fluid, x, BLOCKS_TALL - 1, 4)
+    const poured = fluid.count
+    expect(highest(fluid)).toBeGreaterThan(firstCellOf(BLOCKS_TALL - 1))
+
+    // One second is many times over what it takes to fall this far.
+    for (let i = 0; i < 60; i++) fluid.step(1 / 60)
+
+    expect(fluid.count).toEqual(poured)
+    // All of it poured in as one block row's worth per column, so once it has
+    // landed it stands about a block deep and nothing is left up top.
+    expect(highest(fluid)).toBeLessThan(firstCellOf(2))
   })
 
   test('the solid border sits outside the blocks, not inside them', () => {
@@ -99,7 +150,7 @@ describe('world grid', () => {
     for (let i = CELL_BORDER; i < fluid.width - CELL_BORDER; i++)
       expect(fluid.isSolid(i, 0)).toBe(false)
     // ...and the rest of the frame is untouched, corners included, so no cell
-    // the pressure solve can reach ever sits on the edge of the grid.
+    // the pressure solve can reach sits on the edge of the grid.
     expect(fluid.isSolid(0, 0)).toBe(true)
     expect(fluid.isSolid(fluid.width - 1, 0)).toBe(true)
     for (let j = 0; j < fluid.height; j++) {


### PR DESCRIPTION
Two faults, both reported at the bottom of the world, and unrelated to each other.

## 1. Scrolling was jerky

The scroll was measured in frames rather than in seconds:

```js
step(1 / 60)                          // once per animation frame
scrollProgress += dt / SECONDS_PER_ROW
```

Every frame advanced the world by the same distance whatever that frame had actually taken. A 16ms frame and a 40ms frame moved it equally far, so each long frame — and a solver spending 10-20ms a step produces plenty — showed up as a stutter. Off a 60Hz display it was not even the right speed: at 120Hz the world scrolled, and the water ran, at double time.

Both pages now glide on the wall clock. The solver keeps its fixed step and its old bargain — elapsed time is banked and spent one step at a time, **at most one step per frame**, so a machine that cannot manage 60 steps a second still just gets slow water and never a frame asked to do two steps' work because the last one ran long.

The `/dom` page had the same complaint in a blunter form: a whole pixel every 100ms, which is ten discrete jumps a second however smoothly the rest of the page paints. It is on the animation frame now too, and its glide moved from 1250 per-block `top` values to a single transform on their container — which is what makes sub-pixel motion affordable there at all.

Measured in-browser over 10 seconds of scrolling, the drawn offset is now exactly linear in the frame timestamp:

| | rate | ideal | worst deviation from constant velocity |
|---|---|---|---|
| fluid page | 1.0000 cells/s | 1 | 0 cells over 600 frames |
| `/dom` page | 10.000 px/s | 10 | 0 px over 210 frames |

`/dom` was also drawn at 169 distinct positions in those 10 seconds, where the old timer could only ever produce ~100, in whole-pixel steps.

## 2. The bottom row did not hold its water

The pressure solve reaches a cell's four neighbours by plain index arithmetic, so the outermost cells must never hold water. That rim was being carved **out of** the outermost blocks, on the grounds that half a block of it is invisible against the terrain.

It was invisible. It was not harmless. The bottom row of the world could only ever hold half its water, and it held it on a ledge halfway up a block that nothing was drawing — so water arriving on the floor appeared to drain away into a row that plainly had room for it, and the row a scroll brings in arrived half full. The same applied to the top row and both side columns.

The rim now sits **outside** the block world. A block owns its own square of cells and nothing else, and the floor the water rests on is exactly the floor that is drawn.

Same seed, same world, before and after — note the dark band under the water along the bottom edge on the left, and that the water is now 32,256 particles rather than 30,512:

| before | after |
|---|---|
| water stops on an invisible ledge | water reaches the drawn floor |

The mapping between blocks and cells moved out of the composable into `app/scripts/fluid/worldGrid.ts`, where it can be tested — and is, including a regression test that a block of water is worth the same wherever it is poured, and that water poured into the bottom row settles filling that row rather than half of it.

## Still there, deliberately

While confirming the above I found a **third** bottom-of-the-world artifact and did not fix it, because fixing it properly is a design decision rather than a bug fix.

During a glide the world is drawn up to one block higher than it sits, and there is nothing below the bottom row to draw in the gap that opens. The block, light and depth textures clamp, so the bottom of the canvas shows a vertical smear of row 0 with no water in it, growing over the two seconds of the glide and snapping back — and a new row pops in rather than sliding in. Smoothing the scroll makes this *more* visible than it was, since the band now grows evenly instead of in jerks.

The honest fix is a staging row below the camera, the way `/dom` already does it (`height - (scrolling ? 1 : 0)`). On a fixed-aspect canvas that means either showing 24 rows instead of 25, or generating a 26-row world — which would break the "same seed is the same cave system on both pages" property the README claims. Worth doing, worth choosing on purpose.

## Checks

- `npm test` — 18 passed, including 5 new ones
- `npm run typecheck` — clean
- `npx prettier --check` on the changed files — clean (`npm run lint` fails on this checkout for CRLF reasons that predate this branch and hit 19 untouched files)
- Driven in a browser: paint, drag-paint, drain, add-water, scroll on and off, and `/dom`'s grid verified still 1250 blocks on an exact 20px 50x25 lattice

🤖 Generated with [Claude Code](https://claude.com/claude-code)